### PR TITLE
fix FocusListener in ExportConfigurationDialog - 02-03-03

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,33 @@
+2015-09-05 Sandro Ventura <sandro.ventura@cern.ch>
+        * tag V02-03-03
+        * fix a missing FocusListener in ExportConfigurationDialog class which could cause directories tree corruption
+
+2015-07-29 Sandro Ventura <sandro.ventura@cern.ch>
+	* tag V02-03-02
+	* small fixes for direct writing to v2
+	* updated DB choice pull down menu for v2 accounts
+
+2015-07-23 Andrea Bocci <andrea.bocci@cern.ch>
+	* tag V02-03-01
+	* from Sandro: fix for u_lockedconf field name
+
+2015-07-22 Andrea Bocci <andrea.bocci@cern.ch>
+	* tag V02-03-00
+	* clean up after merge from ConfDB v1
+	* deploy at http://confdb.web.cern.ch/confdb/v2/
+
+2015-05-28 Sandro Ventura <sandro.ventura@cern.ch>
+	* tag V02-02-05
+	* merge with ConfDB v1 updates
+
+2015-04-11 Sandro Ventura <sandro.ventura@cern.ch>
+	* tag V02-02-04
+	* second ConfDB v2 version deployed online
+
+2015-02-23 Sandro Ventura <sandro.ventura@cern.ch>
+	* tag V02-01-02
+	* first ConfDB v2 version deployed online
+
 2015-05-08 Andrea Bocci <andrea.bocci@cern.ch>
 	* tag V01-08-04
 	* update build environment for lxplus and the `confdb` user

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V02-02-05
+confdb.version=V02-03-03
 confdb.contact=sandro.ventura@cern.ch
-confdb.url=http://cms-project-confdb-hltgdr.web.cern.ch/cms-project-confdb-hltgdr/browser/
+confdb.url=http://confdb.web.cern.ch/confdb/v2/

--- a/src/confdb/gui/ExportConfigurationDialog.java
+++ b/src/confdb/gui/ExportConfigurationDialog.java
@@ -196,6 +196,10 @@ public class ExportConfigurationDialog extends JDialog
             jTreeDirectories.setCellRenderer(new DirectoryTreeCellRenderer());
             jTreeDirectories.setCellEditor(new DirectoryTreeCellEditor(jTreeDirectories, new DirectoryTreeCellRenderer()));
             
+         // register focus listener to save current edit by clicking elsewhere.
+         // See: TreeDirectoryFocusListener.java
+            jTreeDirectories.addFocusListener(new TreeDirectoryFocusListener(jTreeDirectories, targetDB));
+
             // register additional listener callbacks
             jTreeDirectories.addTreeSelectionListener(new TreeSelectionListener() {
                     public void valueChanged(TreeSelectionEvent e) {


### PR DESCRIPTION
Added one missing FocusListener in ExportConfigurationDialog class which could cause directory tree corruption when creating a new directory
