### PR TITLE
fix FocusListener in ExportConfigurationDialog - 02-03-03

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-09-05 Sandro Ventura <sandro.ventura@cern.ch>
+        * tag V02-03-03
+        * fix a missing FocusListener in ExportConfigurationDialog class which could cause directories tree corruption
+
 2015-07-29 Sandro Ventura <sandro.ventura@cern.ch>
 	* tag V02-03-02
 	* small fixes for direct writing to v2

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V02-03-02
+confdb.version=V02-03-03
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=http://confdb.web.cern.ch/confdb/v2/

--- a/src/confdb/gui/ExportConfigurationDialog.java
+++ b/src/confdb/gui/ExportConfigurationDialog.java
@@ -196,6 +196,10 @@ public class ExportConfigurationDialog extends JDialog
             jTreeDirectories.setCellRenderer(new DirectoryTreeCellRenderer());
             jTreeDirectories.setCellEditor(new DirectoryTreeCellEditor(jTreeDirectories, new DirectoryTreeCellRenderer()));
             
+         // register focus listener to save current edit by clicking elsewhere.
+         // See: TreeDirectoryFocusListener.java
+            jTreeDirectories.addFocusListener(new TreeDirectoryFocusListener(jTreeDirectories, targetDB));
+
             // register additional listener callbacks
             jTreeDirectories.addTreeSelectionListener(new TreeSelectionListener() {
                     public void valueChanged(TreeSelectionEvent e) {


### PR DESCRIPTION
Added a FocusListener  in ExportConfigurationDialog class which could cause directory tree corruption when creating new directories