### PR TITLE
ES-VESInputTag fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-05-08 Sandro Ventura <sandro.ventura@cern.ch>
+	* tag V01-08-05
+	* add Fix bugs in (V)ESInputTag implementation
+
 2015-05-08 Andrea Bocci <andrea.bocci@cern.ch>
 	* tag V01-08-04
 	* update build environment for lxplus and the `confdb` user

--- a/parser/ConfdbLoadParamsFromConfigs.py
+++ b/parser/ConfdbLoadParamsFromConfigs.py
@@ -330,7 +330,9 @@ class ConfdbLoadParamsfromConfigs:
                                "string":"StringParamValues",
                                "vstring":"VStringParamValues",
                                "InputTag":"InputTagParamValues",
+                               "ESInputTag":"InputTagParamValues",
                                "VInputTag":"VInputTagParamValues",
+                               "VESInputTag":"VInputTagParamValues",
                                "EventID":"EventIDParamValues",
                                "VEventID":"VEventIDParamValues",
                                "FileInPath":"FileInPathParamValues"}
@@ -1087,9 +1089,6 @@ class ConfdbLoadParamsfromConfigs:
         if(paramid):
             returnid = paramid[0]
         else:
-            if(parametertype == "ESInputTag"):
-                parametertype = "InputTag"
-            
             parametertypeint = self.paramtypedict[parametertype]
             paramtable = self.paramtabledict[parametertype]
 
@@ -1141,6 +1140,15 @@ class ConfdbLoadParamsfromConfigs:
                         if(parametertype == "VInputTag"):
                             if(str(parametervectorvalue).startswith("cms.InputTag") or str(parametervectorvalue).startswith("cms.untracked.InputTag")):
                                 if (parametervectorvalue.configTypeName().find("InputTag") != -1):
+                                    parametervectorvalue = parametervectorvalue.value()
+
+                        # Treat VESInputTags. Elements may be returned as either InputTag objects, or
+                        # plain strings without a configTypeName() method. So try to decide which 
+                        # based on the string representation of the parameter name, then check 
+                        # configTypeName() if it looks like an InputTag to be sure...
+                        if(parametertype == "VESInputTag"):
+                            if(str(parametervectorvalue).startswith("cms.ESInputTag") or str(parametervectorvalue).startswith("cms.untracked.ESInputTag")):
+                                if (parametervectorvalue.configTypeName().find("ESInputTag") != -1):
                                     parametervectorvalue = parametervectorvalue.value()
 
                         # Protect against numerical overflows

--- a/parser/ConfdbOracleModuleLoader.py
+++ b/parser/ConfdbOracleModuleLoader.py
@@ -905,6 +905,27 @@ class ConfdbOracleModuleLoader:
 			    print "INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newparamid) + ", '" + paramval + "')"
 			thecursor.execute("INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newparamid) + ", '" + paramval + "')")
 
+	    # ESInputTag
+	    elif(paramtype == "ESInputTag"):
+		type = self.paramtypedict['ESInputTag']
+
+		# Fill Parameters table
+		newparamid = self.AddNewParam(thecursor,newsuperid,paramname,type,paramistracked,paramseq)
+
+		# Fill ParameterValues table
+		if(paramval == None or paramval == ''):
+		    if(self.verbose > 2):
+			print "No default parameter value found"
+		else:
+		    if(paramval.find("'") != -1):
+			if(self.verbose > 2):
+			    print "INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newparamid) + ", " + paramval + ")"
+			thecursor.execute("INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newparamid) + ", " + paramval + ")")
+		    else:
+			if(self.verbose > 2):
+			    print "INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newparamid) + ", '" + paramval + "')"
+			thecursor.execute("INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newparamid) + ", '" + paramval + "')")
+
 	    else:
 		print '\tError: Unknown param type ' + paramtype + ' ' + paramname + ' - do nothing'
                 self.globalseqcount = self.globalseqcount - 1
@@ -1020,6 +1041,23 @@ class ConfdbOracleModuleLoader:
 	    # vector<InputTag>
 	    elif(vecptype == "VInputTag" or vecptype == "InputTag" or vecptype == "vtag"):
 		type = self.paramtypedict['VInputTag']
+
+		# Fill Parameters table
+		newparamid = self.AddNewParam(thecursor,newsuperid,vecpname,type,vecpistracked,vecpseq)
+
+		sequencer = 0
+
+		for vecpval in vecpvals:
+		    if(vecpval):
+			# Fill ParameterValues table
+			if(self.verbose > 2):
+			    print "INSERT INTO VInputTagParamValues (paramId, sequenceNb, value) VALUES (" + str(newparamid) + ", " + str(sequencer) + ", '" + vecpval + "')"
+			thecursor.execute("INSERT INTO VInputTagParamValues (paramId, sequenceNb, value) VALUES (" + str(newparamid) + ", " + str(sequencer) + ", '" + vecpval + "')")   
+			sequencer = sequencer + 1
+
+	    # vector<InputTag>
+	    elif(vecptype == "VESInputTag" or vecptype == "ESInputTag"):
+		type = self.paramtypedict['VESInputTag']
 
 		# Fill Parameters table
 		newparamid = self.AddNewParam(thecursor,newsuperid,vecpname,type,vecpistracked,vecpseq)
@@ -1668,8 +1706,10 @@ class ConfdbOracleModuleLoader:
 			print "Parameter is unchanged (" + str(oldparamval) + ", " + str(paramval) + ")"
 
 	    # InputTag
-	    if(paramtype == "InputTag"):
+	    if(paramtype == "InputTag" or paramtype == "ESInputTag"):
 		type = self.paramtypedict['InputTag']
+	        if(paramtype == "ESInputTag"):
+                    type = self.paramtypedict['ESInputTag']
 
 		# Get the old value of this parameter
 		oldparamid = self.RetrieveParamId(thecursor,paramname,oldsuperid)
@@ -2083,8 +2123,11 @@ class ConfdbOracleModuleLoader:
 			    sequencer = sequencer + 1
 
 	    # vector<InputTag>
-	    elif(vecptype == "VInputTag" or vecptype == "InputTag" or vecptype == "vtag"):		
+	    elif(vecptype == "VInputTag" or vecptype == "InputTag" or vecptype == "vtag" or vecptype == "ESInputTag"):		
 		type = self.paramtypedict['VInputTag']
+                if (vecptype == "ESInputTag"):
+                    type = self.paramtypedict['VESInputTag']
+
 		# Get the old value of this parameter
 		oldparamid = self.RetrieveParamId(thecursor,vecpname,oldsuperid)
 		
@@ -2379,7 +2422,7 @@ class ConfdbOracleModuleLoader:
 		    print "\tWarning: Attempted to load a non-string value to FileInPath table:"
 		    print "\t\tstring " + str(psetname) + " = " + str(psetval)
 		    print "\t\tLoading parameter with no default value"
-	    elif(psettype == "InputTag"):
+	    elif(psettype == "InputTag" or psettype == "ESInputTag"):
 		if(psetval.find("'") != -1):
 		    thecursor.execute("INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newparammemberid) + ", " + psetval + ")")
 		else:
@@ -2436,7 +2479,7 @@ class ConfdbOracleModuleLoader:
 		for entry in entries:
 		    thecursor.execute("INSERT INTO VStringParamValues (paramId, sequenceNb, value) VALUES (" + str(newparammemberid) + ", " + str(sequencer) + ", '" + entry.lstrip().rstrip() + "')")   
 		    sequencer = sequencer + 1		
-	    elif(psettype == "VInputTag" or psettype == "vtag"):
+	    elif(psettype == "VInputTag" or psettype == "vtag" or psettype == "VESInputTag"):
 		sequencer = 0
 		entries = psetval.lstrip().rstrip().lstrip('{').rstrip('}').split(',')
 		for entry in entries:
@@ -2630,7 +2673,7 @@ class ConfdbOracleModuleLoader:
 		    print "\t\tstring " + str(vpsetname) + " = " + str(vpsetval)
 		    print "\t\tLoading parameter with no default value" 
 
-	    elif(vpsettype == "InputTag"):
+	    elif(vpsettype == "InputTag" or vpsettype == "ESInputTag"):
 		if(vpsetval.find("'") != -1):
 		    thecursor.execute("INSERT INTO InputTagParamValues (paramId, value) VALUES (" + str(newvparammemberid) + ", " + vpsetval + ")")
 		else:

--- a/sql/hlt_create_db_ORACLE.sql
+++ b/sql/hlt_create_db_ORACLE.sql
@@ -1329,6 +1329,8 @@ INSERT INTO ParameterTypes VALUES (15,'int64');
 INSERT INTO ParameterTypes VALUES (16,'vint64');
 INSERT INTO ParameterTypes VALUES (17,'uint64');
 INSERT INTO ParameterTypes VALUES (18,'vuint64');
+INSERT INTO ParameterTypes VALUES (19,'ESInputTag');
+INSERT INTO ParameterTypes VALUES (20,'VESInputTag');
 
 
 COMMIT;

--- a/sql/hlt_create_procedures_ORACLE.sql
+++ b/sql/hlt_create_procedures_ORACLE.sql
@@ -298,7 +298,7 @@ BEGIN
     END LOOP;
     CLOSE cur_vstring;
   /** load inputtag values */
-  ELSIF parameter_type='InputTag'
+  ELSIF parameter_type='InputTag' OR parameter_type='ESInputTag'
   THEN
     OPEN cur_inputtag;
     FETCH cur_inputtag INTO v_string_value;
@@ -307,7 +307,7 @@ BEGIN
     END IF;
     CLOSE cur_inputtag;
   /** load vinputtag values */
-  ELSIF parameter_type='VInputTag'
+  ELSIF parameter_type='VInputTag' OR parameter_type='VESInputTag'
   THEN
     OPEN cur_vinputtag;
     LOOP

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V01-08-04
+confdb.version=V01-08-05
 confdb.contact=andrea.bocci@cern.ch
 confdb.url=http://confdb.web.cern.ch/confdb/

--- a/src/confdb/db/ConfDB.java
+++ b/src/confdb/db/ConfDB.java
@@ -5746,9 +5746,9 @@ public class ConfDB
 	insertParameterHashMap.put("EventID",    psInsertEventIDParamValue);
 	insertParameterHashMap.put("VEventID",   psInsertVEventIDParamValue);
 	insertParameterHashMap.put("InputTag",   psInsertInputTagParamValue);
-	insertParameterHashMap.put("ESInputTag", psInsertESInputTagParamValue);
+	insertParameterHashMap.put("ESInputTag", psInsertInputTagParamValue);
 	insertParameterHashMap.put("VInputTag",  psInsertVInputTagParamValue);
-	insertParameterHashMap.put("VESInputTag",psInsertVESInputTagParamValue);
+	insertParameterHashMap.put("VESInputTag",psInsertVInputTagParamValue);
 	insertParameterHashMap.put("FileInPath", psInsertFileInPathParamValue);
 
 	ResultSet rs = null;


### PR DESCRIPTION
Changes apply only to v1 ConfDB. In order to have them effective in production on HLTDEV v1 its Oracle stored procedures must be updated. The fix for the GUI has been tested on INT2R.