### PR TITLE
Updating Predefined Connection Parameters including specifying socks proxy or not

### DIFF
--- a/javaws/WebContent/index.html
+++ b/javaws/WebContent/index.html
@@ -34,7 +34,7 @@ ant gui
 
 <h3>Connection details</h3>
 <p>In order to work, the GUI needs to connect to one of the Oracle database at CERN.<br>
-The offline database <b>HLTDEVv2</b> should be accessible from the CERN network and from all institutes
+The offline database <b>HLTDEVv2</b> should be accessible from the CERN network and from all (most?) institutes
 that belong to the CMS collaboration.<br>
 The online database <b>DAQv2</b> is accessible only from the .CMS network at Point 5, while its read-only
 copy <b>ORCOFFv2</b> is accessible from the CERN network. An ssh tunnel can be used to connect from outside.</p>
@@ -45,14 +45,14 @@ telnet cmsr1-s.cern.ch 10121
 </pre>
 If the output is something like
 <pre>
-Trying 188.184.36.76...
+Trying 10.116.96.88...
 Connected to db-rac-349.cern.ch.
 Escape character is '^]'.
 </pre>
 then you can connect to the database.<br>
 If the output is something like
 <pre>
-Trying 188.184.36.76...
+Trying 10.116.96.88...
 telnet: Unable to connect to remote host: Connection refused
 </pre>
 then you cannot connect directly to the database, and you need to use a tunnel.<br>
@@ -61,21 +61,23 @@ then you cannot connect directly to the database, and you need to use a tunnel.<
 Franck Pachot (cc Andrea Bocci)</a> providing the IP address range for your institute,
 and ask to allow it through the CMS database firewall.</p>
 
+<p> Note its probably easier just to tunnel the connection though...</p>
+
 <h3>Connection through a tunnel</h3>
-<p>Starting with the GUI version V02-06-00, the preferred method to connect is to create a dynamic
+<p>Currently the preferred method to connect is to create a dynamic
 forwarding through an ssh connection to lxplus:
 <pre>
 ssh -f -N -D 1080 lxplus.cern.ch
 </pre>
-then start the GUI, select the HLTDEVv2 database, and tick the "SOCKS Proxy" checkmark.<br>
-Change the proxy port number if you used a different local port.</p>
+then start the GUI, select the HLTDEVv2 (socks tunnel) option<br>
+Change the proxy port number if you used a different local port. </p>
 
 <p>If this approach does not work, it is also possible to forward a port.
 Forward the local port 10121 to the database server through an ssh connection to lxplus:
 <pre>
-ssh -f -N -L 10121:188.184.36.85:10121 lxplus.cern.ch
+ssh -f -N -L 10121:10.116.96.89:10121 lxplus.cern.ch
 </pre>
-then start the GUI, select the HLTDEVv2 database, and change the host to <code>localhost</code>.<br>
+then start the GUI, select the HLTDEVv2 (direct tunnel) option.
 Change the server port number if you used a different local port.
 </p>
 

--- a/javaws/WebContent/index.html
+++ b/javaws/WebContent/index.html
@@ -45,14 +45,14 @@ telnet cmsr1-s.cern.ch 10121
 </pre>
 If the output is something like
 <pre>
-Trying 10.116.96.88...
+Trying 10.116.96.89...
 Connected to db-rac-349.cern.ch.
 Escape character is '^]'.
 </pre>
 then you can connect to the database.<br>
 If the output is something like
 <pre>
-Trying 10.116.96.88...
+Trying 10.116.96.89...
 telnet: Unable to connect to remote host: Connection refused
 </pre>
 then you cannot connect directly to the database, and you need to use a tunnel.<br>

--- a/src/conf/confdb.properties
+++ b/src/conf/confdb.properties
@@ -2,7 +2,7 @@
 #  ConfDB properties
 ###################################
 
-confdb.setupCount=4
+confdb.setupCount=6
 
 confdb0.dbSetup=HLTDEVv2
 confdb0.dbType=oracle
@@ -10,29 +10,47 @@ confdb0.dbHost=cmsr1-s.cern.ch, cmsr2-s.cern.ch
 confdb0.dbPort=10121
 confdb0.dbName=cms_cond.cern.ch
 confdb0.dbUser=cms_hlt_gdr_w
+confdb0.proxy=false
 
-confdb1.dbSetup=ORCOFFv2
+confdb1.dbSetup=HLTDEVv2 (socks tunnel)
 confdb1.dbType=oracle
-confdb1.dbHost=cmsonr1-adg1-s.cern.ch, cmsonr2-adg1-s.cern.ch
+confdb1.dbHost=10.116.96.89
 confdb1.dbPort=10121
-confdb1.dbName=cms_orcon_adg.cern.ch
-confdb1.dbUser=cms_hlt_gdr_r
+confdb1.dbName=cms_cond.cern.ch
+confdb1.dbUser=cms_hlt_gdr_w
+confdb1.proxy=true
 
-confdb2.dbSetup=DAQv2
+confdb2.dbSetup=HLTDEVv2 (direct tunnel)
 confdb2.dbType=oracle
-confdb2.dbHost=cmsonr1-s.cms, cmsonrr2-s.cms
+confdb2.dbHost=localhost
 confdb2.dbPort=10121
-confdb2.dbName=cms_omds_lb.cern.ch
+confdb2.dbName=cms_cond.cern.ch
 confdb2.dbUser=cms_hlt_gdr_w
+confdb2.proxy=false
 
-
-confdb3.dbSetup=DAQv2 (tunnel)
+confdb3.dbSetup=ORCOFFv2
 confdb3.dbType=oracle
-confdb3.dbHost=localhost
+confdb3.dbHost=cmsonr1-adg1-s.cern.ch, cmsonr2-adg1-s.cern.ch
 confdb3.dbPort=10121
-confdb3.dbName=cms_omds_tunnel.cern.ch
-confdb3.dbUser=cms_hlt_gdr_w
+confdb3.dbName=cms_orcon_adg.cern.ch
+confdb3.dbUser=cms_hlt_gdr_r
+confdb3.proxy=false
 
+confdb4.dbSetup=DAQv2
+confdb4.dbType=oracle
+confdb4.dbHost=cmsonr1-s.cms, cmsonrr2-s.cms
+confdb4.dbPort=10121
+confdb4.dbName=cms_omds_lb.cern.ch
+confdb4.dbUser=cms_hlt_gdr_w
+confdb4.proxy=false
+
+confdb5.dbSetup=DAQv2 (direct tunnel)
+confdb5.dbType=oracle
+confdb5.dbHost=localhost
+confdb5.dbPort=10121
+confdb5.dbName=cms_omds_tunnel.cern.ch
+confdb5.dbUser=cms_hlt_gdr_w
+confdb5.proxy=false
 #confdb4.dbSetup=online
 #confdb4.dbType=oracle
 #confdb4.dbHost=cmsonr1-v.cms, cmsonr2-v.cms, cmsonr3-v.cms

--- a/src/confdb/db/ConfDBSetups.java
+++ b/src/confdb/db/ConfDBSetups.java
@@ -2,7 +2,7 @@ package confdb.db;
 
 import java.util.ArrayList;
 import java.util.Properties;
-
+import java.lang.Boolean;
 import java.io.InputStream;
 import java.io.IOException;
 
@@ -37,6 +37,8 @@ public class ConfDBSetups {
 	/** database setup db users */
 	private ArrayList<String> users = new ArrayList<String>();
 
+	/** database setup db use proxies */
+       private ArrayList<Boolean> proxies = new ArrayList<Boolean>();
 	//
 	// construction
 	//
@@ -90,6 +92,10 @@ public class ConfDBSetups {
 	public String user(int i) {
 		return users.get(i);
 	}
+       /** retrieve i-th proxy */
+       public Boolean proxy(int i) {
+	        return proxies.get(i);
+	}
 
 	/** retrieve type by label */
 	public String type(String label) {
@@ -120,6 +126,11 @@ public class ConfDBSetups {
 		int index = labels.indexOf(label);
 		return (index >= 0) ? users.get(index) : null;
 	}
+       /** retrieve proxy by label */
+	public Boolean proxy(String label) {
+		int index = labels.indexOf(label);
+		return (index >= 0) ? proxies.get(index) : null;
+	}
 
 	/** initialize from properties file */
 	private void initialize(String fileName) {
@@ -129,6 +140,7 @@ public class ConfDBSetups {
 		names.add("");
 		users.add("");
 		hosts.add("");
+              proxies.add(false);
 
 		try {
 			InputStream inStream = getClass().getResourceAsStream(fileName);
@@ -151,6 +163,8 @@ public class ConfDBSetups {
 				names.add(new String(property));
 				property = properties.getProperty("confdb" + i + ".dbUser");
 				users.add(new String(property));
+				property = properties.getProperty("confdb" + i + ".proxy");
+				proxies.add(new Boolean(Boolean.valueOf(property)));
 			}
 		} catch (IOException e) {
 			System.out.println("Failed to initialize ConfDBSetups from '" + fileName + "': " + e.getMessage());

--- a/src/confdb/gui/DatabaseConnectionDialog.java
+++ b/src/confdb/gui/DatabaseConnectionDialog.java
@@ -418,6 +418,7 @@ public class DatabaseConnectionDialog extends JDialog implements ActionListener,
 		textFieldDbPort.setText(dbSetups.port(selectedIndex));
 		textFieldDbName.setText(dbSetups.name(selectedIndex));
 		textFieldDbUser.setText(dbSetups.user(selectedIndex));
+		checkBoxProxyEnabled.setSelected(dbSetups.proxy(selectedIndex));
 		String dbType = dbSetups.type(selectedIndex);
 		if (dbType.equals("mysql"))
 			mysqlButton.setSelected(true);


### PR DESCRIPTION
Hi All, 

This PR extends the default database connection parameters to have the socks and tunnel options HLTDEV to make things easier for the user.

This PR also extends the default connection parameter configs to also allow specifying if a SOCKS proxy should be used. 