### PR TITLE
Fixing non-global EDAliases being written out

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2021-07-15 Sam Harper 
+	* tag V02-08-02
+	* bug fix: fixes SP EDAliases being mistakenly written out to the menu
+
 2021-06-09 Sam Harper 
 	* tag V02-08-01
 	* bug fixes to parsing empty strings and ESInputTags introduced in V2-08-0, they now properly use "\"\""  as the empty value and empty is now unset

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V02-08-01
+confdb.version=V02-08-02
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v2-gpu/

--- a/src/confdb/converter/python/PythonConfigurationWriter.java
+++ b/src/confdb/converter/python/PythonConfigurationWriter.java
@@ -152,16 +152,6 @@ public class PythonConfigurationWriter implements IConfigurationWriter {
 			str.append("\n");
 		}
 		
-		if (conf.edAliasCount() > 0) {
-			IEDAliasWriter edAliasWriter = converterEngine.getEDAliasWriter();
-			for (int i = 0; i < conf.edAliasCount(); i++) {
-				EDAliasInstance edAlias = conf.edAlias(i);
-				str.append(object);
-				str.append(edAliasWriter.toString(edAlias));
-			}
-			str.append("\n");
-		}
-
 		if (conf.switchProducerCount() > 0) {
 			ISwitchProducerWriter switchProducerWriter = converterEngine.getSwitchProducerWriter();
 			Iterator<SwitchProducer> switchProducerIterator = conf.orderedSwitchProducerIterator();


### PR DESCRIPTION
This PR fixes non-global EDAliases from being written out. These never should be written out, they are written out as part of the switch producer.

A curious puzzle is why only the pixel SP EDAliases were being added to the config's EDAliases and not the ECAL or HCAL. Still for a nother fix

This brings it to V02-08-02