### PR TITLE
fix class name of HtmlSwitchProducerWriter to match expected spelling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,9 @@
-2021-07-15 Sam Harper 
+2021-08-06 Philipp Brummer
+    * tag V02-08-03
+    * bug fix: change HtmlSwitchProducerWriter class name to match expected spelling (HTML to Html)
+        * reported in CMSHLT-2161
+
+2021-07-15 Sam Harper
 	* tag V02-08-02
 	* bug fix: fixes SP EDAliases being mistakenly written out to the menu
 

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V02-08-02
+confdb.version=V02-08-03
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v2-gpu/

--- a/src/confdb/converter/html/HtmlSwitchProducerWriter.java
+++ b/src/confdb/converter/html/HtmlSwitchProducerWriter.java
@@ -4,7 +4,7 @@ import confdb.converter.ConverterEngine;
 import confdb.converter.ISwitchProducerWriter;
 import confdb.data.SwitchProducer;
 
-public class HTMLSwitchProducerWriter implements ISwitchProducerWriter {
+public class HtmlSwitchProducerWriter implements ISwitchProducerWriter {
 	public String toString(SwitchProducer switchProducer, ConverterEngine converterEngine, String indent) {
 		String str = indent + "switchProducer " + decorateName(switchProducer.name()) + " = ";
 		for (int i = 0; i < switchProducer.entryCount(); i++) {


### PR DESCRIPTION
Change class name prefix from HTML to Html as expected by the ConverterFactory.

References CMSHLT-2161