### PR TITLE
Fixes to clean up database connections

### DIFF
--- a/src/confdb/converter/ConverterBase.java
+++ b/src/confdb/converter/ConverterBase.java
@@ -27,6 +27,12 @@ public class ConverterBase
     		database.connect( connection );
     		converterEngine = ConverterFactory.getConverterEngine( format );
     	} catch (Exception e) {
+			//make sure we clean up our connection
+			try {
+				database.disconnect();
+			} catch (DatabaseException dbexcept) {
+				//no action needed
+			}
     		throw new ConverterException( "can't construct converter", e );
     	}
     }
@@ -52,6 +58,11 @@ public class ConverterBase
     	try {
     		database.connect( dbType, dbUrl, dbUser, dbPwrd );
     	} catch (Exception e) {
+			try {
+				database.disconnect();
+			} catch (DatabaseException dbexcept){
+				//no action needed
+			}
     		throw new ConverterException( "can't init database connection", e );
     	}
     }
@@ -62,7 +73,14 @@ public class ConverterBase
     	return database;
     }
 	
-    public ConverterEngine getConverterEngine() 
+	public void disconnect() throws DatabaseException
+	{
+		ConfDB db = getDatabase();
+		if ( db != null ) 
+			db.disconnect();
+	}
+    
+	public ConverterEngine getConverterEngine() 
     {
     	return converterEngine;
     }

--- a/src/confdb/converter/OfflineConverter.java
+++ b/src/confdb/converter/OfflineConverter.java
@@ -39,7 +39,13 @@ public class OfflineConverter extends ConverterBase
 	super(format,dbType,dbUrl,dbUser,dbPwrd);
     }
 
-    
+    /** destructor  */
+	protected void finalize() throws Throwable
+	{
+	super.finalize();
+	disconnect();
+	}
+			
     //
     // member functions
     //

--- a/src/confdb/converter/OnlineConverter.java
+++ b/src/confdb/converter/OnlineConverter.java
@@ -127,9 +127,8 @@ public class OnlineConverter extends ConverterBase
     protected void finalize() throws Throwable
     {
 	super.finalize();
-	ConfDB db = getDatabase();
-	if ( db != null && disconnectOnFinalize )
-	    db.disconnect();
+	if ( disconnectOnFinalize )
+	    disconnect();
     }
 	
     


### PR DESCRIPTION
As reported by Philipp Brummer, the offline converter is leaking connections

See the JIRA: https://its.cern.ch/jira/browse/CMSHLT-2162

As per Philipp's recommendations, a disconnect option is added and cleaned is added in the constructors which would leak on exception. Finally when the condb object is deleted, it now closes the connection. 

Thanks Philipp, much appreciated ;)

