### PR TITLE
Adapting For Initial Release

### DIFF
--- a/src/conf/confdb.properties
+++ b/src/conf/confdb.properties
@@ -2,55 +2,107 @@
 #  ConfDB properties
 ###################################
 
-confdb.setupCount=6
+confdb.setupCount=12
 
-confdb0.dbSetup=HLTDEVv2
+
+
+confdb0.dbSetup=Run3 Offline
 confdb0.dbType=oracle
 confdb0.dbHost=cmsr1-s.cern.ch, cmsr2-s.cern.ch
 confdb0.dbPort=10121
 confdb0.dbName=cms_cond.cern.ch
-confdb0.dbUser=cms_hlt_gdrdev_w
+confdb0.dbUser=cms_hlt_v3_w
 confdb0.proxy=false
 
-confdb1.dbSetup=HLTDEVv2 (socks tunnel)
+confdb1.dbSetup=Run3 Offline (socks tunnel)
 confdb1.dbType=oracle
 confdb1.dbHost=10.116.96.89
 confdb1.dbPort=10121
 confdb1.dbName=cms_cond.cern.ch
-confdb1.dbUser=cms_hlt_gdrdev_w
+confdb1.dbUser=cms_hlt_v3_w
 confdb1.proxy=true
 
-confdb2.dbSetup=HLTDEVv2 (direct tunnel)
+confdb2.dbSetup=Run3 Offline (direct tunnel)
 confdb2.dbType=oracle
 confdb2.dbHost=localhost
 confdb2.dbPort=10121
 confdb2.dbName=cms_cond.cern.ch
-confdb2.dbUser=cms_hlt_gdrdev_w
+confdb2.dbUser=cms_hlt_v3_w
 confdb2.proxy=false
 
-confdb3.dbSetup=ORCOFFv2
+confdb3.dbSetup=Run2 Offline
 confdb3.dbType=oracle
-confdb3.dbHost=cmsonr1-adg1-s.cern.ch, cmsonr2-adg1-s.cern.ch
+confdb3.dbHost=cmsr1-s.cern.ch, cmsr2-s.cern.ch
 confdb3.dbPort=10121
-confdb3.dbName=cms_orcon_adg.cern.ch
+confdb3.dbName=cms_cond.cern.ch
 confdb3.dbUser=cms_hlt_gdr_r
 confdb3.proxy=false
 
-confdb4.dbSetup=DAQv2
+confdb4.dbSetup=Run2 Offline (socks tunnel)
 confdb4.dbType=oracle
-confdb4.dbHost=cmsonr1-s.cms, cmsonrr2-s.cms
+confdb4.dbHost=10.116.96.89
 confdb4.dbPort=10121
-confdb4.dbName=cms_omds_lb.cern.ch
-confdb4.dbUser=cms_hlt_gdr_w
-confdb4.proxy=false
+confdb4.dbName=cms_cond.cern.ch
+confdb4.dbUser=cms_hlt_gdr_r
+confdb4.proxy=true
 
-confdb5.dbSetup=DAQv2 (direct tunnel)
+confdb5.dbSetup=Run2 Offline (direct tunnel)
 confdb5.dbType=oracle
 confdb5.dbHost=localhost
 confdb5.dbPort=10121
-confdb5.dbName=cms_omds_tunnel.cern.ch
-confdb5.dbUser=cms_hlt_gdr_w
+confdb5.dbName=cms_cond.cern.ch
+confdb5.dbUser=cms_hlt_gdr_r
 confdb5.proxy=false
+
+
+confdb6.dbSetup=ORCOFFv2
+confdb6.dbType=oracle
+confdb6.dbHost=cmsonr1-adg1-s.cern.ch, cmsonr2-adg1-s.cern.ch
+confdb6.dbPort=10121
+confdb6.dbName=cms_orcon_adg.cern.ch
+confdb6.dbUser=cms_hlt_gdr_r
+confdb6.proxy=false
+
+confdb7.dbSetup=DAQv2
+confdb7.dbType=oracle
+confdb7.dbHost=cmsonr1-s.cms, cmsonrr2-s.cms
+confdb7.dbPort=10121
+confdb7.dbName=cms_omds_lb.cern.ch
+confdb7.dbUser=cms_hlt_gdr_w
+confdb7.proxy=false
+
+confdb8.dbSetup=DAQv2 (direct tunnel)
+confdb8.dbType=oracle
+confdb8.dbHost=localhost
+confdb8.dbPort=10121
+confdb8.dbName=cms_omds_tunnel.cern.ch
+confdb8.dbUser=cms_hlt_gdr_w
+confdb8.proxy=false
+
+confdb9.dbSetup=Offline Dev
+confdb9.dbType=oracle
+confdb9.dbHost=cmsr1-s.cern.ch, cmsr2-s.cern.ch
+confdb9.dbPort=10121
+confdb9.dbName=cms_cond.cern.ch
+confdb9.dbUser=cms_hlt_gdrdev_w
+confdb9.proxy=false
+
+confdb10.dbSetup=Offline Dev (socks tunnel)
+confdb10.dbType=oracle
+confdb10.dbHost=10.116.96.89
+confdb10.dbPort=10121
+confdb10.dbName=cms_cond.cern.ch
+confdb10.dbUser=cms_hlt_gdrdev_w
+confdb10.proxy=true
+
+confdb11.dbSetup=Offline Dev (direct tunnel)
+confdb11.dbType=oracle
+confdb11.dbHost=localhost
+confdb11.dbPort=10121
+confdb11.dbName=cms_cond.cern.ch
+confdb11.dbUser=cms_hlt_gdrdev_w
+confdb11.proxy=false
+
 #confdb4.dbSetup=online
 #confdb4.dbType=oracle
 #confdb4.dbHost=cmsonr1-v.cms, cmsonr2-v.cms, cmsonr3-v.cms

--- a/src/confdb/db/ConfDB.java
+++ b/src/confdb/db/ConfDB.java
@@ -2214,6 +2214,10 @@ public class ConfDB {
 	public synchronized void lockConfiguration(Configuration config, String userName) throws DatabaseException {
 		reconnect();
 
+		//first check if there is a parent dir, if there is none, it can not be locked
+		if(config.parentDir()==null) {
+			return;
+		}
 		int parentDirId = config.parentDir().dbId();
 		String parentDirName = config.parentDir().name();
 		String configName = config.name();

--- a/src/confdb/gui/CommandActionListener.java
+++ b/src/confdb/gui/CommandActionListener.java
@@ -20,6 +20,7 @@ public class CommandActionListener implements ActionListener
 
     private static final String cmdNew              = "New";
     private static final String cmdOpen             = "Open";
+    private static final String cmdOpenDB           = "Open (Different DB)";
     private static final String cmdOpenOldScehma    = "Open Old Schema";
     private static final String cmdJParse           = "Open Python File";
     private static final String cmdClose            = "Close";
@@ -69,6 +70,7 @@ public class CommandActionListener implements ActionListener
 	if (command.equals(cmdNew))              app.newConfiguration();
 	if (command.equals(cmdJParse))           app.importFromPythonToolDialog();
 	if (command.equals(cmdOpen))             app.openConfiguration();
+    if (command.equals(cmdOpenDB))           app.openConfigurationFromOtherDB();
 	if (command.equals(cmdClose))            app.closeConfiguration();
 	if (command.equals(cmdSave))             app.saveConfiguration(false);
 	if (command.equals(cmdCommentSave))      app.saveConfiguration(true);

--- a/src/confdb/gui/CommandActionListener.java
+++ b/src/confdb/gui/CommandActionListener.java
@@ -29,7 +29,7 @@ public class CommandActionListener implements ActionListener
     private static final String cmdSaveAs           = "Save As";
 
     private static final String cmdImport           = "Import";
-    private static final String cmdImportDB         = "Import from Different DB";
+    private static final String cmdImportDB         = "Import (Different DB)";
     private static final String cmdMigrate          = "Migrate";
     private static final String cmdConvert          = "Convert";
     

--- a/src/confdb/gui/CommandActionListener.java
+++ b/src/confdb/gui/CommandActionListener.java
@@ -37,6 +37,7 @@ public class CommandActionListener implements ActionListener
     private static final String cmdDiff             = "Compare (Diff)";
     private static final String cmdSmartVersions    = "Smart Path Versioning";
     private static final String cmdSmartRenaming    = "Smart Renaming";
+    private static final String cmdConvertToTasks   = "Taskify";
     private static final String cmdPSEditor         = "Edit Prescales";
     private static final String cmdSPSEditor        = "Edit SmartPrescales";
     private static final String cmdMLEditor         = "Edit MessageLogger";
@@ -85,6 +86,7 @@ public class CommandActionListener implements ActionListener
 	if (command.equals(cmdDiff))             app.diffConfigurations();
 	if (command.equals(cmdSmartVersions))    app.smartVersionsConfigurations();
 	if (command.equals(cmdSmartRenaming))    app.smartRenamingConfigurations();
+    if (command.equals(cmdConvertToTasks))   app.convertToTasks();
 	if (command.equals(cmdPSEditor))         app.openPrescaleEditor();
 	if (command.equals(cmdSPSEditor))        app.openSmartPrescaleEditor();
 	if (command.equals(cmdMLEditor))         app.openMessageLoggerEditor();

--- a/src/confdb/gui/CommandActionListener.java
+++ b/src/confdb/gui/CommandActionListener.java
@@ -28,6 +28,7 @@ public class CommandActionListener implements ActionListener
     private static final String cmdSaveAs           = "Save As";
 
     private static final String cmdImport           = "Import";
+    private static final String cmdImportDB         = "Import from Different DB";
     private static final String cmdMigrate          = "Migrate";
     private static final String cmdConvert          = "Convert";
     
@@ -74,6 +75,7 @@ public class CommandActionListener implements ActionListener
 	if (command.equals(cmdSaveAs))           app.saveAsConfiguration();
 
 	if (command.equals(cmdImport))           app.importConfiguration();
+    if (command.equals(cmdImportDB))         app.importConfigurationFromOtherDB();
 	if (command.equals(cmdMigrate))          app.migrateConfiguration();
 	if (command.equals(cmdConvert))          app.convertConfiguration();
 	

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -484,7 +484,7 @@ public class ConfDbGUI {
 
 		GUIFontConfig.setFonts();
 
-		JFrame frame = new JFrame("GDR ConfDbGUI DEVELOPMENT");
+		JFrame frame = new JFrame("GDR ConfDbGUI Run3");
 		frame.setFont(GUIFontConfig.getFont(0));
 
 		ConfDbGUI gui = new ConfDbGUI(frame);

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -633,9 +633,9 @@ public class ConfDbGUI {
 		String dbHost = dbDialog.getDbHost();
 		String dbPort = dbDialog.getDbPort();
 		String dbName = dbDialog.getDbName();
-		String dbUrl = dbDialog.getDbUrl();
 		String dbUser = dbDialog.getDbUser();
 		String dbPwrd = dbDialog.getDbPassword();
+		String dbUrl = sourceDB.setDbParameters(dbPwrd, dbName, dbHost, dbPort);
 		try {
 			sourceDB.connect(dbType, dbUrl, dbUser, dbPwrd);				
 		} catch (DatabaseException e) {
@@ -1471,9 +1471,9 @@ public class ConfDbGUI {
 		String dbHost = dbDialog.getDbHost();
 		String dbPort = dbDialog.getDbPort();
 		String dbName = dbDialog.getDbName();
-		String dbUrl = dbDialog.getDbUrl();
 		String dbUser = dbDialog.getDbUser();
 		String dbPwrd = dbDialog.getDbPassword();
+		String dbUrl = sourceDB.setDbParameters(dbPwrd, dbName, dbHost, dbPort);
 		try {
 			sourceDB.connect(dbType, dbUrl, dbUser, dbPwrd);
 			// ((DatabaseInfoPanel)jPanelDbConnection).connectedToDatabase(dbType,

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -1321,7 +1321,7 @@ public class ConfDbGUI {
 	}
 
 	public void convertToTasks() {
-		ConfigToTaskConverter converter = new ConfigToTaskConverter(currentConfig);
+		ConfigToTaskConverter converter = new ConfigToTaskConverter(currentConfig,jTreeCurrentConfig);
 		converter.convert();
 		
 	}
@@ -5656,9 +5656,11 @@ class CommandTableCellRenderer extends DefaultTableCellRenderer {
 
 class ConfigToTaskConverter {
 	private Configuration cfg;
+	private JTree tree;
 
-	public ConfigToTaskConverter(Configuration cfg){
+	public ConfigToTaskConverter(Configuration cfg,JTree tree){
 		this.cfg = cfg;
+		this.tree = tree;
 	}
 
 	private ArrayList<Sequence> getSequences(ModuleInstance mod){
@@ -5707,6 +5709,7 @@ class ConfigToTaskConverter {
 			if(ref.parent()==mod){
 				this.cfg.removeModuleReference((ModuleReference)ref);
 				return true;
+
 			}
 		}
 		return false;

--- a/src/confdb/gui/ConfigurationTreeActions.java
+++ b/src/confdb/gui/ConfigurationTreeActions.java
@@ -1546,8 +1546,14 @@ public class ConfigurationTreeActions {
 				model.nodeInserted(targetContainer, i);
 			} else if (entry instanceof ModuleReference) {
 				ModuleInstance module = config.module(entry.name());
-				config.insertModuleReference(targetContainer, i, module).setOperator(entry.getOperator());
-				model.nodeInserted(targetContainer, i);
+				//prescale modules are unique to a path and thus must be cloned
+				if(module.template().name().equals("HLTPrescaler")){
+					String newName = Path.hltPrescalerLabel(targetName);
+					ConfigurationTreeActions.CloneModule(tree, (ModuleReference) entry, newName);	
+				}else{
+					config.insertModuleReference(targetContainer, i, module).setOperator(entry.getOperator());
+					model.nodeInserted(targetContainer, i);
+				}
 			} else if (entry instanceof EDAliasReference) {
 				EDAliasInstance edAlias = config.edAlias(entry.name());
 				config.insertEDAliasReference(targetContainer, i, edAlias).setOperator(entry.getOperator());

--- a/src/confdb/gui/ConfigurationTreeActions.java
+++ b/src/confdb/gui/ConfigurationTreeActions.java
@@ -28,6 +28,7 @@ public class ConfigurationTreeActions {
 	//
 	// Parameters
 	//
+	private static boolean globalEDAliasAvailability = false;
 
 	/** copy a parameter into another (v)pset */
 	public static boolean insertParameter(JTree tree, Parameter parameter, ParameterTreeModel parameterTreeModel) {
@@ -966,6 +967,12 @@ public class ConfigurationTreeActions {
 	
 	/** insert a new global EDAlias producer */
 	public static boolean insertGlobalEDAlias(JTree tree) {
+		if (globalEDAliasAvailability) {
+			errorNotificationPanel dialog = new errorNotificationPanel("Error: InsertGlobalEDAlias", "Error GlobalEDAliases are not supported by this database",
+			"This database does not have support for GlobalEDAliases (but supports EDAliases in SwitchProducers) at this time");
+			dialog.createAndShowGUI();
+			return true;
+		}
 		ConfigurationTreeModel model = (ConfigurationTreeModel) tree.getModel();
 		Configuration config = (Configuration) model.getRoot();
 		TreePath treePath = tree.getSelectionPath();

--- a/src/confdb/gui/DatabaseConnectionDialog.java
+++ b/src/confdb/gui/DatabaseConnectionDialog.java
@@ -329,9 +329,6 @@ public class DatabaseConnectionDialog extends JDialog implements ActionListener,
 		textFieldDbUser.addActionListener(this);
 		textFieldDbUser.addFocusListener(this);
 
-		textFieldDbUser.setEditable(false);
-		textFieldDbUser.setEnabled(false);
-
 		textFieldDbPwrd.addActionListener(this);
 		textFieldDbPwrd.addFocusListener(this);
 

--- a/src/confdb/gui/MenuBar.java
+++ b/src/confdb/gui/MenuBar.java
@@ -31,6 +31,7 @@ public class MenuBar {
 	private static final String configMenuCommentSave = "Comment&Save";
 	private static final String configMenuSaveAs = "Save As";
 	private static final String configMenuImport = "Import";
+	private static final String configMenuImportDB = "Import from Different DB";
 	private static final String configMenuMigrate = "Migrate";
 	private static final String configMenuConvert = "Convert";
 
@@ -68,6 +69,7 @@ public class MenuBar {
 	private JMenuItem configMenuSaveAsItem = null;
 
 	private JMenuItem configMenuImportItem = null;
+	private JMenuItem configMenuImportDBItem = null;
 	private JMenuItem configMenuMigrateItem = null;
 	private JMenuItem configMenuConvertItem = null;
 
@@ -110,6 +112,7 @@ public class MenuBar {
 		configMenuCommentSaveItem.setEnabled(true);
 		configMenuSaveAsItem.setEnabled(true);
 		configMenuImportItem.setEnabled(true);
+		configMenuImportDBItem.setEnabled(true);
 		configMenuMigrateItem.setEnabled(true);
 		configMenuConvertItem.setEnabled(true);
 		toolMenuReplaceItem.setEnabled(true);
@@ -132,6 +135,7 @@ public class MenuBar {
 		configMenuCommentSaveItem.setEnabled(false);
 		configMenuSaveAsItem.setEnabled(false);
 		configMenuImportItem.setEnabled(false);
+		configMenuImportDBItem.setEnabled(false);
 		configMenuMigrateItem.setEnabled(false);
 		configMenuConvertItem.setEnabled(false);
 		// toolMenuDiffItem.setEnabled(false);
@@ -233,6 +237,10 @@ public class MenuBar {
 		configMenuImportItem.setActionCommand(configMenuImport);
 		configMenuImportItem.addActionListener(listener);
 		configMenu.add(configMenuImportItem);
+		configMenuImportDBItem = new JMenuItem(configMenuImportDB, KeyEvent.VK_D);
+		configMenuImportDBItem.setActionCommand(configMenuImportDB);
+		configMenuImportDBItem.addActionListener(listener);
+		configMenu.add(configMenuImportDBItem);
 		configMenuMigrateItem = new JMenuItem(configMenuMigrate, KeyEvent.VK_M);
 		configMenuMigrateItem.setActionCommand(configMenuMigrate);
 		configMenuMigrateItem.addActionListener(listener);

--- a/src/confdb/gui/MenuBar.java
+++ b/src/confdb/gui/MenuBar.java
@@ -32,7 +32,7 @@ public class MenuBar {
 	private static final String configMenuCommentSave = "Comment&Save";
 	private static final String configMenuSaveAs = "Save As";
 	private static final String configMenuImport = "Import";
-	private static final String configMenuImportDB = "Import from Different DB";
+	private static final String configMenuImportDB = "Import (Different DB)";
 	private static final String configMenuMigrate = "Migrate";
 	private static final String configMenuConvert = "Convert";
 

--- a/src/confdb/gui/MenuBar.java
+++ b/src/confdb/gui/MenuBar.java
@@ -41,6 +41,7 @@ public class MenuBar {
 	private static final String toolMenuDiff = "Compare (Diff)";
 	private static final String toolMenuSmartVersions = "Smart Path Versioning";
 	private static final String toolMenuSmartRenaming = "Smart Renaming";
+	private static final String toolMenuConvertToTasks = "Taskify";
 	private static final String toolMenuPSEditor = "Edit Prescales";
 	private static final String toolMenuSPSEditor = "Edit SmartPrescales";
 	private static final String toolMenuMLEditor = "Edit MessageLogger";
@@ -78,6 +79,7 @@ public class MenuBar {
 	private JMenuItem toolMenuDiffItem = null;
 	private JMenuItem toolMenuSmartVersionsItem = null;
 	private JMenuItem toolMenuSmartRenamingItem = null;
+	private JMenuItem toolMenuConvertToTasksItem = null;
 	private JMenuItem toolMenuReplaceItem = null;
 	private JMenuItem toolMenuPSEditorItem = null;
 	private JMenuItem toolMenuSPSEditorItem = null;
@@ -122,6 +124,7 @@ public class MenuBar {
 		toolMenuDiffItem.setEnabled(true);
 		toolMenuSmartVersionsItem.setEnabled(true);
 		toolMenuSmartRenamingItem.setEnabled(true);
+		toolMenuConvertToTasksItem.setEnabled(true);
 		toolMenuPSEditorItem.setEnabled(true);
 		toolMenuSPSEditorItem.setEnabled(true);
 		toolMenuMLEditorItem.setEnabled(true);
@@ -144,6 +147,7 @@ public class MenuBar {
 		// toolMenuDiffItem.setEnabled(false);
 		toolMenuSmartVersionsItem.setEnabled(false);
 		toolMenuSmartRenamingItem.setEnabled(false);
+		toolMenuConvertToTasksItem.setEnabled(false);
 		toolMenuReplaceItem.setEnabled(false);
 		toolMenuPSEditorItem.setEnabled(false);
 		toolMenuSPSEditorItem.setEnabled(false);
@@ -274,7 +278,10 @@ public class MenuBar {
 		toolMenuSmartRenamingItem = new JMenuItem(toolMenuSmartRenaming, KeyEvent.VK_N);
 		toolMenuSmartRenamingItem.setActionCommand(toolMenuSmartRenaming);
 		toolMenuSmartRenamingItem.addActionListener(listener);
-		toolMenu.add(toolMenuSmartRenamingItem);
+		toolMenuConvertToTasksItem = new JMenuItem(toolMenuConvertToTasks);
+		toolMenuConvertToTasksItem.setActionCommand(toolMenuConvertToTasks);
+		toolMenuConvertToTasksItem.addActionListener(listener);
+		toolMenu.add(toolMenuConvertToTasksItem);
 		toolMenuReplaceItem = new JMenuItem(toolMenuReplace, KeyEvent.VK_R);
 		toolMenuReplaceItem.setActionCommand(toolMenuReplace);
 		toolMenuReplaceItem.addActionListener(listener);

--- a/src/confdb/gui/MenuBar.java
+++ b/src/confdb/gui/MenuBar.java
@@ -281,7 +281,7 @@ public class MenuBar {
 		toolMenuConvertToTasksItem = new JMenuItem(toolMenuConvertToTasks);
 		toolMenuConvertToTasksItem.setActionCommand(toolMenuConvertToTasks);
 		toolMenuConvertToTasksItem.addActionListener(listener);
-		toolMenu.add(toolMenuConvertToTasksItem);
+		//toolMenu.add(toolMenuConvertToTasksItem);
 		toolMenuReplaceItem = new JMenuItem(toolMenuReplace, KeyEvent.VK_R);
 		toolMenuReplaceItem.setActionCommand(toolMenuReplace);
 		toolMenuReplaceItem.addActionListener(listener);

--- a/src/confdb/gui/MenuBar.java
+++ b/src/confdb/gui/MenuBar.java
@@ -24,6 +24,7 @@ public class MenuBar {
 	/** menu bar item names: configMenu */
 	private static final String configMenuNew = "New";
 	private static final String configMenuOpen = "Open";
+	private static final String configMenuOpenDB = "Open (Different DB)";
 	private static final String configMenuOpenOld = "Open Old Schema";
 	private static final String configMenuJParse = "Open Python File";
 	private static final String configMenuClose = "Close";
@@ -62,6 +63,7 @@ public class MenuBar {
 	private JMenuItem configMenuNewItem = null;
 	private JMenuItem configMenuJParseItem = null;
 	private JMenuItem configMenuOpenItem = null;
+	private JMenuItem configMenuOpenDBItem = null;
 	private JMenuItem configMenuOpenOldItem = null;
 	private JMenuItem configMenuCloseItem = null;
 	private JMenuItem configMenuCommentSaveItem = null;
@@ -107,6 +109,7 @@ public class MenuBar {
 		dbConnectionIsEstablished();
 		configMenuNewItem.setEnabled(true);
 		configMenuOpenItem.setEnabled(true);
+		configMenuOpenDBItem.setEnabled(true);
 		configMenuCloseItem.setEnabled(true);
 		configMenuSaveItem.setEnabled(true);
 		configMenuCommentSaveItem.setEnabled(true);
@@ -156,6 +159,7 @@ public class MenuBar {
 		configMenuNewItem.setEnabled(true);
 		configMenuJParseItem.setEnabled(true);
 		configMenuOpenItem.setEnabled(true);
+		configMenuOpenDBItem.setEnabled(true);
 		configMenuOpenOldItem.setEnabled(true);
 		toolMenuDiffItem.setEnabled(true);
 		toolMenuSmartVersionsItem.setEnabled(true);
@@ -171,6 +175,7 @@ public class MenuBar {
 		configMenuOpenOldItem.setEnabled(false);
 		configMenuJParseItem.setEnabled(false);
 		configMenuOpenItem.setEnabled(false);
+		configMenuOpenDBItem.setEnabled(false);
 		toolMenuDiffItem.setEnabled(false);
 		toolMenuSmartVersionsItem.setEnabled(false);
 		toolMenuSmartRenamingItem.setEnabled(false);
@@ -205,6 +210,10 @@ public class MenuBar {
 		configMenuOpenItem.setActionCommand(configMenuOpen);
 		configMenuOpenItem.addActionListener(listener);
 		configMenu.add(configMenuOpenItem);
+		configMenuOpenDBItem = new JMenuItem(configMenuOpenDB);
+		configMenuOpenDBItem.setActionCommand(configMenuOpenDB);
+		configMenuOpenDBItem.addActionListener(listener);
+		configMenu.add(configMenuOpenDBItem);
 		configMenuOpenOldItem = new JMenuItem(configMenuOpenOld, KeyEvent.VK_Q);
 		configMenuOpenOldItem.setActionCommand(configMenuOpenOld);
 		configMenuOpenOldItem.addActionListener(listener);

--- a/src/confdb/gui/ModuleInsertDialog.java
+++ b/src/confdb/gui/ModuleInsertDialog.java
@@ -138,13 +138,25 @@ public class ModuleInsertDialog extends JDialog {
 	/** initialize GUI components */
 	private JPanel initComponents() {
 		JPanel jPanel = new JPanel();
+        jPanel.setLayout(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
 
-        jPanel.add(jComboBoxModule);
-        jPanel.add(jButtonOK);
-        jPanel.add(jButtonCancel);
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+
+        jPanel.add(jComboBoxModule,constraints);
+        constraints.gridx = 1;
         jPanel.add(jButtonNew);
-        jPanel.add(jButtonExisting);
-        jPanel.add(jButtonClone);
+        constraints.gridx = 2;
+        jPanel.add(jButtonExisting,constraints);
+        constraints.gridx = 3;
+        jPanel.add(jButtonClone,constraints);
+        constraints.gridx = 1;
+        constraints.gridy = 1;
+        jPanel.add(jButtonOK,constraints);
+        constraints.gridx = 2;
+        jPanel.add(jButtonCancel,constraints);
         
         
         ButtonGroup addGroup  = new ButtonGroup();
@@ -153,8 +165,8 @@ public class ModuleInsertDialog extends JDialog {
         addGroup.add(jButtonClone);
         
         initComboBox();
-        setComboBoxEntriesExistingMod(true);
-        jButtonExisting.setSelected(true);
+        setComboBoxEntriesNewMod();
+        jButtonNew.setSelected(true);
         jButtonOK.setText("OK");		
 		jButtonCancel.setText("Cancel");
 
@@ -164,7 +176,8 @@ public class ModuleInsertDialog extends JDialog {
     private void initComboBox() {     
         jComboBoxModule.setEditable(true);
 		jComboBoxModule.setBorder(BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.LOWERED));
-		AutoCompletion.enable(jComboBoxModule);
+		jComboBoxModule.setPreferredSize(new Dimension(800,jComboBoxModule.getPreferredSize().height));
+        AutoCompletion.enable(jComboBoxModule);
     }
     private void setComboBoxEntriesNewMod() {     
         //if allready set, dont reset

--- a/src/confdb/gui/ModuleInsertDialog.java
+++ b/src/confdb/gui/ModuleInsertDialog.java
@@ -108,31 +108,23 @@ public class ModuleInsertDialog extends JDialog {
         }else{
             ConfigurationTreeActions.insertReference(tree, "Module", (String) jComboBoxModule.getSelectedItem());
         }
-        System.err.println("clicked: "+jComboBoxModule.getSelectedItem());
-        System.err.println("action: "+e);
     }
     private void newButtonActionPerformed(ActionEvent e) {
         clone = false;
         setComboBoxEntriesNewMod();
-        System.err.println("newButton: ");
-        System.err.println("action: "+e);
     }
     private void existingButtonActionPerformed(ActionEvent e) {
         clone = false;
-        System.err.println("existingButton: ");
-        System.err.println("action: "+e);
         setComboBoxEntriesExistingMod(true);
     }
     private void cloneButtonActionPerformed(ActionEvent e) {
         clone = true;
-        System.err.println("cloneButton: ");
-        System.err.println("action: "+e);
         setComboBoxEntriesExistingMod(true);
     }
     
 
 	private void jComboBoxModelActionPerformed(ActionEvent e) {
-        System.err.println(jComboBoxModule.getSelectedItem());
+        jComboBoxModule.getSelectedItem();
 	}
 
 	/** initialize GUI components */

--- a/src/confdb/gui/ToolBar.java
+++ b/src/confdb/gui/ToolBar.java
@@ -27,7 +27,7 @@ public class ToolBar {
 	private static final String cmdSaveAs = "Save As";
 
 	private static final String cmdImport = "Import";
-	private static final String cmdImportDB = "Import from Different DB";
+	private static final String cmdImportDB = "Import (Different DB)";
 	private static final String cmdMigrate = "Migrate";
 	private static final String cmdConvert = "Convert";
 

--- a/src/confdb/gui/ToolBar.java
+++ b/src/confdb/gui/ToolBar.java
@@ -27,6 +27,7 @@ public class ToolBar {
 	private static final String cmdSaveAs = "Save As";
 
 	private static final String cmdImport = "Import";
+	private static final String cmdImportDB = "Import from Different DB";
 	private static final String cmdMigrate = "Migrate";
 	private static final String cmdConvert = "Convert";
 
@@ -54,6 +55,7 @@ public class ToolBar {
 	private JButton jButtonSaveAs = new JButton();
 
 	private JButton jButtonImport = new JButton();
+	private JButton jButtonImportDB = new JButton();
 	private JButton jButtonMigrate = new JButton();
 	private JButton jButtonConvert = new JButton();
 
@@ -95,6 +97,7 @@ public class ToolBar {
 		jButtonSave.setEnabled(true);
 		jButtonSaveAs.setEnabled(true);
 		jButtonImport.setEnabled(true);
+		jButtonImportDB.setEnabled(true);
 		jButtonMigrate.setEnabled(true);
 		jButtonConvert.setEnabled(true);
 		jButtonReplace.setEnabled(true);
@@ -116,6 +119,7 @@ public class ToolBar {
 		jButtonSaveAs.setEnabled(false);
 
 		jButtonImport.setEnabled(false);
+		jButtonImportDB.setEnabled(false);
 		jButtonMigrate.setEnabled(false);
 		jButtonConvert.setEnabled(false);
 		jButtonReplace.setEnabled(false);
@@ -196,6 +200,12 @@ public class ToolBar {
 		jButtonImport.setToolTipText("import components from another configuration");
 		jButtonImport.setIcon(new ImageIcon(getClass().getResource("/ImportIcon.png")));
 		jToolBar.add(jButtonImport);
+
+		jButtonImportDB.setActionCommand(cmdImportDB);
+		jButtonImportDB.addActionListener(listener);
+		jButtonImportDB.setToolTipText("import components from another configuration");
+		jButtonImportDB.setIcon(new ImageIcon(getClass().getResource("/ImportIcon.png")));
+		jToolBar.add(jButtonImportDB);
 
 		jButtonMigrate.setActionCommand(cmdMigrate);
 		jButtonMigrate.addActionListener(listener);


### PR DESCRIPTION
This PR adds in the features needed for the initial release

It specifically allows us to import and open configs in other databases. It also disables global ED alias support for now as that is less well tested and may confuse users (and we want to focus on bugs elsewhere)

It renames the user name box being editable and sets up the new database connection selections and renames the window title to reflect its the Run3 option.  

