### PR TITLE
Fixes directory removal bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-10-07 Sam Harper
+    * tag V03-00-05
+	* bug fix: directory now not removed from gui if the db operation to remove failures
+
+
 2021-10-06 Bogdan Sataric & Sam Harper
     * tag V03-00-04
 	* bumped version to V3 to reflect new features

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-00-04
+confdb.version=V03-00-05
 confdb.contact=sandro.ventura@cern.ch
-confdb.url=https://confdb.web.cern.ch/confdb/v2-gpu/
+confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -486,7 +486,7 @@ public class ConfDbGUI {
 
 		GUIFontConfig.setFonts();
 
-		JFrame frame = new JFrame("GDR ConfDbGUI Run3");
+		JFrame frame = new JFrame("GDR ConfDbGUI V3");
 		frame.setFont(GUIFontConfig.getFont(0));
 
 		ConfDbGUI gui = new ConfDbGUI(frame);

--- a/src/confdb/gui/DirectoryTreeMouseListener.java
+++ b/src/confdb/gui/DirectoryTreeMouseListener.java
@@ -130,10 +130,17 @@ public class DirectoryTreeMouseListener extends MouseAdapter implements ActionLi
 			directoryTree.setSelectionPath(newTreePath);
 			directoryTree.startEditingAtPath(newTreePath);
 		} else if (actionCmd.equals(RMV_DIRECTORY)) {
-			Directory parentDir = selDir.parentDir();
-			int iChildDir = parentDir.indexOfChildDir(selDir);
-			parentDir.removeChildDir(selDir);
-			directoryTreeModel.nodeRemoved(parentDir, iChildDir, selDir);
+			try {
+				database.removeDirectory(selDir);
+				Directory parentDir = selDir.parentDir();
+				int iChildDir = parentDir.indexOfChildDir(selDir);
+				parentDir.removeChildDir(selDir);
+				directoryTreeModel.nodeRemoved(parentDir, iChildDir, selDir);
+			} catch (DatabaseException ex) {
+				ex.printStackTrace();
+				JOptionPane.showMessageDialog(null, ex.toString(), "DB Exception Removing Dir", JOptionPane.ERROR_MESSAGE,
+							null);
+			}
 		}
 	}
 
@@ -166,12 +173,8 @@ public class DirectoryTreeMouseListener extends MouseAdapter implements ActionLi
 
 	/** TreeModelListener: treeNodesRemoved() */
 	public void treeNodesRemoved(TreeModelEvent e) {
-		Directory dirToBeRemoved = (Directory) (e.getChildren()[0]);
-		try {
-			database.removeDirectory(dirToBeRemoved);
-		} catch (DatabaseException ex) {
-			ex.printStackTrace();
-		}
+		//the db operation is now done before removing the tree node 
+		//to see if it succeeds
 	}
 
 	/** TreeModelListener: treeNodesInserted() */


### PR DESCRIPTION
Empty directories can be removed by confdb. However there is a bug where if the DB operation fails for whatever reason, the directory is still removed in the GUI and there is no indication of an issue to the user. This means the top level directory can then be deleted as the gui thinks it is empty and then the problems start....

This change  now requires the db operation to succeed before removing it from the GUI.

Note it is still possible  to trigger this bug if you have two guis open. GUI1 opens the tree, adds a directory. GUI2 then opens the tree, adds a sub dir of the directory. GUI1 still thinks the directory is empty as it hasnt refreshed its info and it can delete the directory. 

Finally a small bug fix to the window title was done at the same time "Run3" ->"V3" to better reflect the new naming