### PR TITLE
added whitespaces around comma preceding Tasks in (End)Paths

### DIFF
--- a/src/confdb/converter/python/PythonPathWriter.java
+++ b/src/confdb/converter/python/PythonPathWriter.java
@@ -38,7 +38,7 @@ public class PythonPathWriter implements IPathWriter
 			if(nonTaskStr.isEmpty() || taskStr.isEmpty()){
 			    str += nonTaskStr + taskStr;
 			}else{
-			    str += nonTaskStr + ","+taskStr;
+			    str += nonTaskStr + " , " + taskStr;
 			}
 		}
 		


### PR DESCRIPTION
Just to maintain the current convention in terms of how modules are spaced inside (End)Paths.

I wasn't sure about the target branch. Since this change is really minor, I went for the default `confdbv3`, instead of passing from `confdbv3-beta`.

Partly addresses https://github.com/cms-sw/hlt-confdb/issues/32.

Not tested.