### PR TITLE
Allow JPythonParser to work from any folder

### DIFF
--- a/src/confdb/parser/JPythonParser.java
+++ b/src/confdb/parser/JPythonParser.java
@@ -131,6 +131,7 @@ public class JPythonParser
 
     /** exec py cmd */
     public void pyCmd(String pycmd) {
+        System.out.println(pycmd);
         pythonInterpreter.exec(pycmd);
     }
 
@@ -166,7 +167,9 @@ public class JPythonParser
             pyCmd("import sys");
             pyCmd("sys.path.append('"+path+"')");   // add the .py file's path
             pyCmd("import pycimport");              // load bytecode .pyc files if available
-	    pyCmd("sys.path.append('python')");
+            pyCmd("pyPath = '/'.join(sys.exec_prefix.split('/')[:-1])+'/python'"); //get .../hlt-confdb/python path
+            pyCmd("print(pyPath)");
+            pyCmd("sys.path.append(pyPath)");
 
             /////////////////////////////////////////////////////////
 

--- a/src/confdb/parser/JPythonParser.java
+++ b/src/confdb/parser/JPythonParser.java
@@ -167,7 +167,7 @@ public class JPythonParser
             pyCmd("import sys");
             pyCmd("sys.path.append('"+path+"')");   // add the .py file's path
             pyCmd("import pycimport");              // load bytecode .pyc files if available
-            pyCmd("pyPath = '/'.join(sys.exec_prefix.split('/')[:-1])+'/python'"); //get .../hlt-confdb/python path
+            pyCmd("pyPath = '/'.join(sys.exec_prefix.split('/')[:-1])+'/python'"); //get .../hlt-confdb/python path from .../hlt-confdb/ext
             pyCmd("print(pyPath)");
             pyCmd("sys.path.append(pyPath)");
 


### PR DESCRIPTION
If you launch ConfDb from an external folder (eg. `./hlt-confdb/start` instead of `./start`), you will not be able to parse the attached file: [test_BROKEN.py.txt](https://github.com/cms-sw/hlt-confdb/files/7514297/test_BROKEN.py.txt).

This PR solves this problem and adds some log from python.

Tested in both my local PC and on lxplus.
It has not been tested on .jnlp