### PR TITLE
change name of `cms.Schedule` to "schedule"

### DIFF
--- a/src/confdb/converter/python/PythonConfigurationWriter.java
+++ b/src/confdb/converter/python/PythonConfigurationWriter.java
@@ -214,7 +214,7 @@ public class PythonConfigurationWriter implements IConfigurationWriter {
 		}
 
 		if (conf.pathCount() > 0) {
-			str.append("\n" + object + "HLTSchedule = cms.Schedule( *(");
+			str.append("\n" + object + "schedule = cms.Schedule( *(");
 			for (int i = 0; i < conf.pathCount(); i++) {
 				Path path = conf.path(i);
 				//we need the "," when there is just one path


### PR DESCRIPTION
**Description:**

This is the change needed in `ConfDB` to produce python configurations where the name of the `cms.Schedule` is "schedule", as requested in https://github.com/cms-sw/cmssw/issues/35842.

As discussed in TSG on Nov-15, the plan would be to deploy this update by the end of November (which coincides with the opening of the last `12_2_X` pre-release).

The change is very simple, but I thought it'd be okay to make a PR to track things better, and in case any discussion is needed.

**Validation:**

None.