### PR TITLE
V03-01-00

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-11-29 Marino Missiroli
+    * tag V03-01-00
+	* adds whitespaces around comma preceding Tasks in Paths/EndPaths (changes python output)
+	* allows JPythonParser to work from any folder
+	* changes name of cms.Schedule to "schedule" (changes python output)
+
 2021-11-04 Sam Harper
     * tag V03-00-08
 	* forbid the saving of menus with modules on a task which are also directly on a sequence or path
@@ -7,12 +13,12 @@
 2021-10-18 Sam Harper
     * tag V03-00-07
 	* added Mateusz to admins
-	* read only setup for the P5 database added 	
+	* read only setup for the P5 database added
 	* forbidding the saving of menus which have streams that have unassinged paths
 	* disabling the option to directly adding a path to a stream
 	* parsing bug fix for empty strings
 	* diff bug fix where objects with same name but different type (eg module vs switch producer) no longer causes a crash
-	
+
 2021-10-07 Sam Harper
     * tag V03-00-06
 	* bug fix: selectEvents no longer assumed to be first entry of an output module

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://confdb.web.cern.ch/confdb/v3/gui/
 the alternative way is to use the ./start script
 ```bash
 git clone git@github.com:cms-sw/hlt-confdb.git
-cd hlt-confdb.git
+cd hlt-confdb
 ./start
 ```
 
@@ -15,24 +15,24 @@ cd hlt-confdb.git
 
 The following branches are defined
 
-  * confdbv1: v1 converter used in Run1
-  * confdbv2: v2 converter used in Run2
-  * confdbv3: v3 converter (currently in use
-  * confdbv3-beta: beta version of the v3 converter to be at the bleeding edge
-  * confdbv3-test: test version of the v3 converter, will break frequently
+  * `confdbv1`: v1 converter used in Run1
+  * `confdbv2`: v2 converter used in Run2
+  * `confdbv3`: v3 converter (currently in use
+  * `confdbv3-beta`: beta version of the v3 converter to be at the bleeding edge
+  * `confdbv3-test`: test version of the v3 converter, will break frequently
 
-Note the confdbv3-beta and confdbv3-test do not have their history preserved and will be frequently
-force synced to condbv3 
+Note the `confdbv3-beta` and `confdbv3-test` do not have their history preserved and will be frequently
+force synced to `confdbv3`.
 
 ## versioning policy
 
-the confdbv3 will be frequently released and pushed to the web server for users
+The `confdbv3` will be frequently released and pushed to the web server for users.
 
-the version format is V\<converter-version\>-\<major-version\>-\<minor-version\>, eg V03-00-01
+The version format is V\<converter-version\>-\<major-version\>-\<minor-version\>, e.g. `V03-00-01`.
 
 The converter version corresponds to v3, v2, v1 and implies a major database scheme change
 The major version changes whenever the python output of the menu changes, ie the same menu will now have a differnt python output. It is also permissable to increase the version number when a major feature is added, in fact this is recommended, it is just mandidatory when the python output changes. It is policy to only install major versions on the DAQ. 
-The minor version is for all other changes
+The minor version is for all other changes.
 
 ## deployment instructions
 
@@ -40,9 +40,10 @@ The minor version is for all other changes
   1. then change the version number in [src/conf/confdb.version](src/conf/confdb.version)
   1. make the PR with this changes and merge it (and any other changes you wish to make for this release)
   1. create a [release](https://github.com/Sam-Harper/hlt-confdb/releases/new) with title of the version (eg V03-01-00). Tag it with this version as well, using "create new tag: VXX-YY-ZZ on publish"
-  1. log into lxplus as confdb (ping trigger management for password)
-  1. go to directory with this repo cloned there (currently ~/private/hlt-confdb)
+  1. log into `lxplus` as `confdb` (ping trigger management for password)
+  1. go to directory with this repo cloned there (currently `~/private/hlt-confdb`)
   1. move to the branch you wish to deploy and ensure you have the latest version
-  1. run `./deploy` script. this will automatically deploy to the correct location using the branch name, striping confdb from the start of the name to get the name to deploy to
+  1. run `./deploy` script. this will automatically deploy to the correct location using the branch name, stripping `confdb` from the start of the name to get the name to deploy to
 
-
+After deployment, make sure that changes in the `confdbv3` branch are also propagated to the `confdbv3-beta` and `confdbv3-test` branches if necessary.
+The two development branches should always be a superset of the stable branch.

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-00-08
+confdb.version=V03-01-00
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/converter/python/PythonConfigurationWriter.java
+++ b/src/confdb/converter/python/PythonConfigurationWriter.java
@@ -214,7 +214,7 @@ public class PythonConfigurationWriter implements IConfigurationWriter {
 		}
 
 		if (conf.pathCount() > 0) {
-			str.append("\n" + object + "HLTSchedule = cms.Schedule( *(");
+			str.append("\n" + object + "schedule = cms.Schedule( *(");
 			for (int i = 0; i < conf.pathCount(); i++) {
 				Path path = conf.path(i);
 				//we need the "," when there is just one path

--- a/src/confdb/converter/python/PythonPathWriter.java
+++ b/src/confdb/converter/python/PythonPathWriter.java
@@ -38,7 +38,7 @@ public class PythonPathWriter implements IPathWriter
 			if(nonTaskStr.isEmpty() || taskStr.isEmpty()){
 			    str += nonTaskStr + taskStr;
 			}else{
-			    str += nonTaskStr + ","+taskStr;
+			    str += nonTaskStr + " , " + taskStr;
 			}
 		}
 		

--- a/src/confdb/parser/JPythonParser.java
+++ b/src/confdb/parser/JPythonParser.java
@@ -131,6 +131,7 @@ public class JPythonParser
 
     /** exec py cmd */
     public void pyCmd(String pycmd) {
+        System.out.println(pycmd);
         pythonInterpreter.exec(pycmd);
     }
 
@@ -166,7 +167,9 @@ public class JPythonParser
             pyCmd("import sys");
             pyCmd("sys.path.append('"+path+"')");   // add the .py file's path
             pyCmd("import pycimport");              // load bytecode .pyc files if available
-	    pyCmd("sys.path.append('python')");
+            pyCmd("pyPath = '/'.join(sys.exec_prefix.split('/')[:-1])+'/python'"); //get .../hlt-confdb/python path
+            pyCmd("print(pyPath)");
+            pyCmd("sys.path.append(pyPath)");
 
             /////////////////////////////////////////////////////////
 

--- a/src/confdb/parser/JPythonParser.java
+++ b/src/confdb/parser/JPythonParser.java
@@ -167,7 +167,7 @@ public class JPythonParser
             pyCmd("import sys");
             pyCmd("sys.path.append('"+path+"')");   // add the .py file's path
             pyCmd("import pycimport");              // load bytecode .pyc files if available
-            pyCmd("pyPath = '/'.join(sys.exec_prefix.split('/')[:-1])+'/python'"); //get .../hlt-confdb/python path
+            pyCmd("pyPath = '/'.join(sys.exec_prefix.split('/')[:-1])+'/python'"); //get .../hlt-confdb/python path from .../hlt-confdb/ext
             pyCmd("print(pyPath)");
             pyCmd("sys.path.append(pyPath)");
 


### PR DESCRIPTION
This release includes

 - [cms-sw/hlt-confdb#33](https://github.com/cms-sw/hlt-confdb/pull/33): adds whitespaces around comma preceding Tasks in Paths/EndPaths (changes python output)
 - [cms-sw/hlt-confdb#35](https://github.com/cms-sw/hlt-confdb/pull/35): allows `JPythonParser` to work from any folder
 - [cms-sw/hlt-confdb#36](https://github.com/cms-sw/hlt-confdb/pull/36): changes name of `cms.Schedule` from "HLTSchedule" to "schedule" (changes python output)

"Major-version" number is increased, because the python output changes wrt versions `V03-0*-**`.