### PR TITLE
Dataset Path Bug Fixes for V03-02-01

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-02-15 Sam Harper
+    * tag V03-02-01
+    * bug fix: standard paths can now have a trigger results filter if that trigger results filter has usePathStatus=True
+
 2022-02-10 Sam Harper
     * tag V03-02-00
 	* reworked datasets to use DatasetPaths to select their events and all that entails

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,15 @@
 2022-02-15 Sam Harper
     * tag V03-02-01
     * bug fix: standard paths can now have a trigger results filter if that trigger results filter has usePathStatus=True
+	* dataset paths now are constrained to have their dataset path filter before their prescale module
+	    * the reason for this is an individual fu can lock to only outputing on some instances of a split dataset if there is a prescale in the dataset path filter
+		* eg say there its split into 4 paths and the dataset path filter simply has a prescale of 2
+		   * event 1: passes path 0 prescale filter, dataset path filter count goes to 1, fails as 1%2!=0
+		   * event 2: passes path 1 prescale filter, dataset path filter count goes to 2, passes as 2%2==0
+		   * event 3: passes path 2, dataset path filter fails
+		   * event 4: passes path 3, dataset path filter passes
+		   * event 1: passes path 0, dataset path filter fails
+		   * and so on, only paths 1 and 3 select. Now each fu will have a different offset so it'll be random for a given fu for which paths it locks to but best to fix it
 
 2022-02-10 Sam Harper
     * tag V03-02-00

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-02-00
+confdb.version=V03-02-01
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/data/PrimaryDataset.java
+++ b/src/confdb/data/PrimaryDataset.java
@@ -366,7 +366,11 @@ public class PrimaryDataset extends DatabaseEntry
             cfg.insertSequenceReference(this.datasetPath, 0, beginSeq);            
             cfg.insertModuleReference(this.datasetPath,1,"HLTPrescaler",Path.hltPrescalerLabel(this.datasetPath.name()));
             addPathFilter(cfg,existingPathFilter);
+            
         }else{
+            if(existingPathFilter!=null){
+                System.err.println("PrimaryDataset::createDatasetPath error, specifying an existing path filter with the dataset path pre existing, the path filter will be ignored");
+            }
             setPathFilter();
         }
     }
@@ -518,7 +522,9 @@ public class PrimaryDataset extends DatabaseEntry
     
     private void addPathFilter(Configuration cfg,PathFilter existingPathFilter) {
         
-        ModuleReference pathFilterRef =  cfg.insertModuleReference(this.datasetPath,this.datasetPath.entryCount(),pathFilterType(),existingPathFilter!=null ? existingPathFilter.name() : pathFilterDefaultName());
+        //the path filter must be always before the hlt prescaler which means index 1 as only 3 things are allowed on
+        //a dataset path
+        ModuleReference pathFilterRef =  cfg.insertModuleReference(this.datasetPath,1,pathFilterType(),existingPathFilter!=null ? existingPathFilter.name() : pathFilterDefaultName());
 
     
         ModuleInstance pathFilterMod = (ModuleInstance) pathFilterRef.parent(); 

--- a/src/confdb/data/SmartPrescaleTable.java
+++ b/src/confdb/data/SmartPrescaleTable.java
@@ -164,6 +164,14 @@ public class SmartPrescaleTable {
         //in fact all paths probably wont from now on (usePathStatus=true)
         if (((InputTagParameter) module.parameter("hltResults")).valueAsString().length() <= 2 && dataset==null) hasAccessToHLTResults = false;
 
+        //now we quickly check if it has usePathStatus = true and thus has access to HLT results
+        Parameter usePathStatus = module.findParameter("usePathStatus");
+        if(usePathStatus!=null){
+            if( (Boolean)((BoolParameter) usePathStatus).value()==true) {
+                hasAccessToHLTResults = true;
+            }
+        }
+
         hasAccessToL1TResults = (((InputTagParameter) module.parameter("l1tResults")).valueAsString().length() > 2);
 
         update();


### PR DESCRIPTION
This PR has two bug fixes

1) smart prescalers are now allowed on standard paths as long as usePathStatus = True is set. This is necessary for complex trigger expressions not supported by dataset paths (eg express ORing several muon paths other and prescaling the result

2) the ordering of dataset paths prescale modules have changed. In order to avoid locking a given fu to a subset of split paths under certain circumstances , the prescale module has to be after the path filter. 