### PR TITLE
Fixing Import Crash when object typo changes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-02-24 Sam Harper
+    * tag V03-02-02
+	* bug fix: can now deep import paths which will have an object change type (ie module goes to switch producer)
+
 2022-02-15 Sam Harper
     * tag V03-02-01
     * bug fix: standard paths can now have a trigger results filter if that trigger results filter has usePathStatus=True

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-02-01
+confdb.version=V03-02-02
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/diff/Diff.java
+++ b/src/confdb/diff/Diff.java
@@ -1513,14 +1513,22 @@ public class Diff {
 				if (r.isChanged())
 					result.addComparison(r);
 				if (parent2 instanceof ReferenceContainer) {
-					Comparison c = compareContainersIgnoreStreams((ReferenceContainer) parent1,
-							(ReferenceContainer) parent2);
-					if (!c.isIdentical())
-						result.addComparison(c);
+					if (parent1 instanceof ReferenceContainer || parent1 ==null) {
+						Comparison c = compareContainersIgnoreStreams((ReferenceContainer) parent1,
+								(ReferenceContainer) parent2);
+						if (!c.isIdentical())
+							result.addComparison(c);
+					}else{
+						result.addComparison(new DiffTypesComparison(parent1,parent2));
+					}
 				} else if (parent2 instanceof ModuleInstance || parent2 instanceof EDAliasInstance) {
-					Comparison c = compareInstances((Instance) parent1, (Instance) parent2);
-					if (!c.isIdentical())
-						result.addComparison(c);
+					if(parent1 instanceof Instance || parent1 ==null){
+						Comparison c = compareInstances((Instance) parent1, (Instance) parent2);
+						if (!c.isIdentical())
+							result.addComparison(c);
+					}else{
+						result.addComparison(new DiffTypesComparison(parent1,parent2));
+					}
 				} else if (parent2 instanceof OutputModule) {
 					if (parent1 == null || (parent1 instanceof OutputModule)) {
 						// avoid checking the Streams using the flag TRUE.

--- a/src/confdb/diff/DiffTypesComparison.java
+++ b/src/confdb/diff/DiffTypesComparison.java
@@ -1,0 +1,57 @@
+package confdb.diff;
+
+import confdb.data.Referencable;
+
+/**
+ * DiffTypesComparison
+ * ------------------
+ * @author Sam Harper
+ * 
+ * compares different types (calling function should ensure they are different)
+ * result will always be RESULT_CHANGED 
+ *
+ */
+public class DiffTypesComparison extends Comparison {
+	//
+	// member data
+	//
+
+	/** old instance */
+	private Referencable oldReferencable = null;
+
+	/** new instance */
+	private Referencable newReferencable = null;
+
+	//
+	// construction
+	//
+
+	/** standard constructor */
+	public DiffTypesComparison(Referencable oldReferencable, Referencable newReferencable) {
+		this.oldReferencable = oldReferencable;
+		this.newReferencable = newReferencable;
+	}
+
+	//
+	// member functions
+	//
+
+	/** determine the result of the comparison */
+	public int result() {
+		return RESULT_CHANGED;
+	}
+
+	/** plain-text representation of the comparison */
+	public String toString() {
+        
+	    //return oldReferencable.name()+"changed type from "+oldReferencable.getClass()+" to "+newReferencable.getClass();
+        return oldReferencable.name() + resultAsString();
+        
+	}
+
+	/** html representation of the comparison */
+	public String toHtml() {
+		return "<html>"+oldReferencable.name()+"<b></html>";
+	}
+
+}


### PR DESCRIPTION
This fixes the deep import crash when the type of an object changes (ie from Module to SwitchProducer and vice versa)

