### PR TITLE
V03-02-03

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,7 @@
 2022-02-24 Sam Harper
     * tag V03-02-03
 	* bug fix: redraw gui command now works (listener wasnt updated for name change)
-	* paths in a dataset filter can no longer be prescaled to 0 using the smart prescale dialog
-	   * this removes them from the dataset but does so in a way which doesnt alert the gui
+	* paths in a dataset filter now explicily remain in the triggerConditions when prescaled to 0
 	* prescales and smart prescales are now transfered over when doing the convert to path based
 
 2022-02-24 Sam Harper

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,11 @@
 2022-02-24 Sam Harper
+    * tag V03-02-03
+	* bug fix: redraw gui command now works (listener wasnt updated for name change)
+	* paths in a dataset filter can no longer be prescaled to 0 using the smart prescale dialog
+	   * this removes them from the dataset but does so in a way which doesnt alert the gui
+	* prescales and smart prescales are now transfered over when doing the convert to path based
+
+2022-02-24 Sam Harper
     * tag V03-02-02
 	* bug fix: can now deep import paths which will have an object change type (ie module goes to switch producer)
 

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-02-02
+confdb.version=V03-02-03
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/data/Configuration.java
+++ b/src/confdb/data/Configuration.java
@@ -1763,21 +1763,23 @@ public class Configuration implements IConfiguration {
 					}
 				}
 			}
-			//now we need to remove any path in a dataset which was not the smart prescaler
+			//now we need to prescale to zero any path in a dataset which was not the smart prescaler
+			//dataset smart prescales physically have a zero entry while non dataset smart prescales
+			//omitted 0 entries
+			//this is mainly to due to non dataset smart prescales having all paths in the stream
+			//in their prescale table but they dont write the zero ones out to the triggerConditions
+			//as it would be hard to read in python and its equavalent
+			//however dataset path smart prescalers define the dataset and thus the 0 entrysneed to remain
 			Iterator<PrimaryDataset> datasetIt = stream.datasetIterator();
 			while(datasetIt.hasNext()){
 				PrimaryDataset dataset = datasetIt.next();
-				Iterator<Path> pathsInDatasetIt = dataset.pathIterator();
-				ArrayList<Path> pathsToRemove = new ArrayList<Path>();
+				Iterator<Path> pathsInDatasetIt = dataset.pathIterator();				
 				while(pathsInDatasetIt.hasNext()){
 					Path path = pathsInDatasetIt.next();
 					if(!pathsInSmartPrescaler.contains(path)){
-						pathsToRemove.add(path);
+						dataset.addPathPrescale(path.name(), 0L);						
 					}
-				}
-				for(Path path : pathsToRemove){
-					dataset.removePath(path);
-				}
+				}				
 			}
 		}
 	}

--- a/src/confdb/data/PrimaryDataset.java
+++ b/src/confdb/data/PrimaryDataset.java
@@ -518,6 +518,13 @@ public class PrimaryDataset extends DatabaseEntry
         return contentsAndIndex;
     }
 
+    public void addPathPrescale(String pathName,Long prescale)
+    {
+        if(datasetPath!=null){
+            pathFilter.addPathPrescale(pathName, prescale);
+        }
+
+    }
 
     
     private void addPathFilter(Configuration cfg,PathFilter existingPathFilter) {
@@ -758,6 +765,22 @@ public class PrimaryDataset extends DatabaseEntry
                 return true;                
             }else{
                 return false;
+            }
+        }
+
+        /**
+         * adds the path prescale, can assume no compound path experessions
+         * intended for the auto transfer of prescales from endpath smart prescalers on initial 
+         * conversion
+         */
+        public void addPathPrescale(String pathName,Long prescale){
+            for(int entryNr=0;entryNr<this.pathFilterParam.vectorSize();entryNr++){       
+                String pathNameAndPrescaleStr = (String) this.pathFilterParam.value(entryNr);       
+                SmartPrescaleTableRow pathNameAndPrescale = new SmartPrescaleTableRow(pathNameAndPrescaleStr);
+                if(pathName.equals(pathNameAndPrescale.pathName)){
+                    this.pathFilterParam.setValue(entryNr,pathName+ " / "+prescale*pathNameAndPrescale.prescale);
+                    break;
+                }
             }
         }
 

--- a/src/confdb/data/SmartPrescaleTable.java
+++ b/src/confdb/data/SmartPrescaleTable.java
@@ -130,6 +130,9 @@ public class SmartPrescaleTable {
         return true;
     }
 
+    public PrimaryDataset dataset(){
+        return dataset;
+    }
 
     //
     // private member functions

--- a/src/confdb/gui/CommandActionListener.java
+++ b/src/confdb/gui/CommandActionListener.java
@@ -43,7 +43,7 @@ public class CommandActionListener implements ActionListener
     private static final String cmdMLEditor         = "Edit MessageLogger";
     private static final String cmdJavaCode         = "Execute Java Code";
     private static final String cmdUPEditor         = "Add Untracked Parameter";
-    private static final String cmdResetGUI         = "Reset GUI";
+    private static final String cmdResetGUI         = "Redraw GUI";
 
 
     private static final String cmdTrack            = "Track InputTags";

--- a/src/confdb/gui/SmartPrescaleDialog.java
+++ b/src/confdb/gui/SmartPrescaleDialog.java
@@ -190,7 +190,9 @@ public class SmartPrescaleDialog extends JDialog {
 				String condition = smartPrescaleTable.get(i).prescaleCondition(j);
 				if (!condition.equals("")) {
 					//this is where the / 0 is caught
-					if ((!smartPrescaleTable.get(i).simple(j)) || (smartPrescaleTable.get(i).prescale(j) != 0)) {
+					if ((!smartPrescaleTable.get(i).simple(j)) || (smartPrescaleTable.get(i).prescale(j) != 0) ||
+				        (smartPrescaleTable.get(i).prescale(j)==0 && smartPrescaleTable.get(i).dataset()!=null)
+					) {
 						parameterTriggerConditions.addValue(smartPrescaleTable.get(i).prescaleCondition(j));
 					}
 				}
@@ -351,14 +353,8 @@ class SmartPrescaleTableModel extends AbstractTableModel {
 	/** set the value of a table cell */
 	public void setValueAt(Object value, int row, int col) {
 		if (col == 1) {		
-			if((Long) value > 0 || smartPrescaleTable.dataset()==null){
-				smartPrescaleTable.modRowSetScale(row, (Long) value);
-				// fireTableStructureChanged();
-				fireTableDataChanged();
-			}else{
-				String msg = new String("Prescales set here for datasets must non zero postive numbers.\nA prescale of zero removes the path from the dataset, if you want to do this, please remove via the dataset menu");
-				JOptionPane.showMessageDialog(null, msg,"Invalid Prescale Value", JOptionPane.WARNING_MESSAGE);
-			}
+			smartPrescaleTable.modRowSetScale(row, (Long) value);	
+			fireTableDataChanged();
 			return;
 		}
 

--- a/src/confdb/gui/SmartPrescaleDialog.java
+++ b/src/confdb/gui/SmartPrescaleDialog.java
@@ -189,6 +189,7 @@ public class SmartPrescaleDialog extends JDialog {
 			for (int j = 0; j < smartPrescaleTable.get(i).prescaleConditionCount(); j++) {
 				String condition = smartPrescaleTable.get(i).prescaleCondition(j);
 				if (!condition.equals("")) {
+					//this is where the / 0 is caught
 					if ((!smartPrescaleTable.get(i).simple(j)) || (smartPrescaleTable.get(i).prescale(j) != 0)) {
 						parameterTriggerConditions.addValue(smartPrescaleTable.get(i).prescaleCondition(j));
 					}
@@ -349,10 +350,15 @@ class SmartPrescaleTableModel extends AbstractTableModel {
 
 	/** set the value of a table cell */
 	public void setValueAt(Object value, int row, int col) {
-		if (col == 1) {
-			smartPrescaleTable.modRowSetScale(row, (Long) value);
-			// fireTableStructureChanged();
-			fireTableDataChanged();
+		if (col == 1) {		
+			if((Long) value > 0 || smartPrescaleTable.dataset()==null){
+				smartPrescaleTable.modRowSetScale(row, (Long) value);
+				// fireTableStructureChanged();
+				fireTableDataChanged();
+			}else{
+				String msg = new String("Prescales set here for datasets must non zero postive numbers.\nA prescale of zero removes the path from the dataset, if you want to do this, please remove via the dataset menu");
+				JOptionPane.showMessageDialog(null, msg,"Invalid Prescale Value", JOptionPane.WARNING_MESSAGE);
+			}
 			return;
 		}
 


### PR DESCRIPTION
This PR bumps us to V03-02-03

It has the following changes:

- prescales and smart prescales are transfered to the dataset path when "convert to path based is selected 
- redraw GUI now works 
- a path in a dataset path can no longer be prescaled to 0 in the smart prescale dialog as that removes the path from the dataset in an improper way
  - non datasetpath smartprescales have have paths set to 0 as before