### PR TITLE
Fixes for GPU Setup in CMSSW_12_3 : V03-03-00

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,9 @@
 	* converter now adds ProcessAcceleratorCUDA to configs with release template >=12_3
 	* python package updated to CMSSW_12_3_0
 	* following names are now reserved: ProcessAcceleratorCUDA, HLTConfigVersion, schedule
+	* global psets are now checked when considering name uniquenes and have name uniqueness enforced
+	  on creation
+	* smart renaming icon and menu entry now restored
 
 2022-03-15 Sam Harper
     * tag V03-02-04

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@
 	* global psets are now checked when considering name uniquenes and have name uniqueness enforced
 	  on creation
 	* smart renaming icon and menu entry now restored
+	* now checks that the default column in the prescale service exists on menu save
 
 2022-03-15 Sam Harper
     * tag V03-02-04

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-04-01 Sam Harper
+    * tag V03-02-05
+	* added DAQ3 Val DB to the DB options
+
 2022-03-15 Sam Harper
     * tag V03-02-04
 	* bug fix: dataset paths were not properly associated when migrating

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
-2022-04-01 Sam Harper
-    * tag V03-02-05
+2022-04-19 Sam Harper
+    * tag V03-03-00
 	* added DAQ3 Val DB to the DB options
+	* converter now adds ProcessAcceleratorCUDA to configs with release template >=12_3
+	* python package updated to CMSSW_12_3_0
+	* following names are now reserved: ProcessAcceleratorCUDA, HLTConfigVersion, schedule
 
 2022-03-15 Sam Harper
     * tag V03-02-04

--- a/python/FWCore/ParameterSet/Config.py
+++ b/python/FWCore/ParameterSet/Config.py
@@ -136,6 +136,7 @@ class Process(object):
         self.__dict__['_Process__partialschedules'] = {}
         self.__isStrict = False
         self.__dict__['_Process__modifiers'] = Mods
+        self.__dict__['_Process__accelerators'] = {}
         self.options = Process.defaultOptions_()
         self.maxEvents = Process.defaultMaxEvents_()
         self.maxLuminosityBlocks = Process.defaultMaxLuminosityBlocks_()
@@ -228,6 +229,7 @@ class Process(object):
                                       allowAnyLabel_ = required.untracked.uint32
                                   )
                               ),
+                              accelerators = untracked.vstring('*'),
                               wantSummary = untracked.bool(False),
                               fileMode = untracked.string('FULLMERGE'),
                               forceEventSetupCacheClearOnNewRun = untracked.bool(False),
@@ -325,6 +327,10 @@ class Process(object):
         """returns a dict of the services that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__services)
     services = property(services_,doc="dictionary containing the services for the process")
+    def processAccelerators_(self):
+        """returns a dict of the ProcessAccelerators that have been added to the Process"""
+        return DictTypes.FixedKeysDict(self.__accelerators)
+    processAccelerators = property(processAccelerators_,doc="dictionary containing the ProcessAccelerators for the process")
     def es_producers_(self):
         """returns a dict of the esproducers that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__esproducers)
@@ -708,6 +714,9 @@ class Process(object):
         if typeName in self.__dict__:
             self.__dict__[typeName]._inProcess = False
         self.__dict__[typeName]=mod
+    def _placeAccelerator(self,typeName,mod):
+        self._place(typeName, mod, self.__accelerators)
+        self.__dict__[typeName]=mod
     def load(self, moduleName):
         moduleName = moduleName.replace("/",".")
         module = __import__(moduleName)
@@ -1003,6 +1012,7 @@ class Process(object):
         result+=self._dumpPythonList(self.analyzers_(), options)
         result+=self._dumpPythonList(self.outputModules_(), options)
         result+=self._dumpPythonList(self.services_(), options)
+        result+=self._dumpPythonList(self.processAccelerators_(), options)
         result+=self._dumpPythonList(self.es_producers_(), options)
         result+=self._dumpPythonList(self.es_sources_(), options)
         result+=self._dumpPython(self.es_prefers_(), options)
@@ -1149,9 +1159,10 @@ class Process(object):
     def _insertSwitchProducersInto(self, parameterSet, labelModules, labelAliases, itemDict, tracked):
         modules = parameterSet.getVString(tracked, labelModules)
         aliases = parameterSet.getVString(tracked, labelAliases)
+        accelerators = parameterSet.getVString(False, "@selected_accelerators")
         for name,value in itemDict.items():
             value.appendToProcessDescLists_(modules, aliases, name)
-            value.insertInto(parameterSet, name)
+            value.insertInto(parameterSet, name, accelerators)
         modules.sort()
         aliases.sort()
         parameterSet.addVString(tracked, labelModules, modules)
@@ -1379,6 +1390,7 @@ class Process(object):
 
         self.validate()
         processPSet.addString(True, "@process_name", self.name_())
+        self.handleProcessAccelerators(processPSet)
         all_modules = self.producers_().copy()
         all_modules.update(self.filters_())
         all_modules.update(self.analyzers_())
@@ -1430,6 +1442,47 @@ class Process(object):
         #if self.source_() == None and self.looper_() == None:
         #    raise RuntimeError("No input source was found for this process")
         pass
+
+    def handleProcessAccelerators(self, parameterSet):
+        # 'cpu' accelerator is always implicitly there
+        allAccelerators = set(["cpu"])
+        availableAccelerators = set(["cpu"])
+        for acc in self.__dict__['_Process__accelerators'].values():
+            allAccelerators.update(acc.labels())
+            availableAccelerators.update(acc.enabledLabels())
+        availableAccelerators = sorted(list(availableAccelerators))
+        parameterSet.addVString(False, "@available_accelerators", availableAccelerators)
+
+        # Resolve wildcards
+        selectedAccelerators = []
+        if "*" in self.options.accelerators:
+            if len(self.options.accelerators) >= 2:
+                raise ValueError("process.options.accelerators may contain '*' only as the only element, now it has {} elements".format(len(self.options.accelerators)))
+            selectedAccelerators = availableAccelerators
+        else:
+            import fnmatch
+            resolved = set()
+            invalid = []
+            for pattern in self.options.accelerators:
+                acc = [a for a in availableAccelerators if fnmatch.fnmatchcase(a, pattern)]
+                if len(acc) == 0:
+                    if not any(fnmatch.fnmatchcase(a, pattern) for a in allAccelerators):
+                        invalid.append(pattern)
+                else:
+                   resolved.update(acc)
+            # Sanity check
+            if len(invalid) != 0:
+                raise ValueError("Invalid pattern{} of {} in process.options.accelerators, valid values are {} or a pattern matching to some of them.".format(
+                    "s" if len(invalid) > 2 else "",
+                    ",".join(invalid),
+                    ",".join(sorted(list(allAccelerators)))))
+            selectedAccelerators = sorted(list(resolved))
+        parameterSet.addVString(False, "@selected_accelerators", selectedAccelerators)
+
+        # Customize
+        wrapped = ProcessForProcessAccelerator(self)
+        for acc in self.__dict__['_Process__accelerators'].values():
+            acc.apply(wrapped, selectedAccelerators)
 
     def prefer(self, esmodule,*args,**kargs):
         """Prefer this ES source or producer.  The argument can
@@ -1824,6 +1877,88 @@ class ProcessModifier(object):
                 self.__func(process)
                 self.__seenProcesses.add(process)
 
+class ProcessAccelerator(_ConfigureComponent,_Unlabelable):
+    """A class used to specify possible compute accelerators in a Process
+    instance. It is intended to be derived for any
+    accelerator/portability technology, and provides hooks such that a
+    specific customization can be applied to the Process on a worker
+    node at the point where the python configuration is serialized for C++.
+
+    The customization must not change the configuration hash. To
+    enforce this reuirement, the customization gets a
+    ProcessForProcessAccelerator wrapper that gives access to only
+    those parts of the configuration that can be changed. Nevertheless
+    it would be good to have specific unit test for each deriving
+    class to ensure that all combinations of the enabled accelerators
+    give the same configuration hash.
+    """
+    def __init__(self):
+        pass
+    def _place(self, name, proc):
+        proc._placeAccelerator(self.type_(), self)
+    def type_(self):
+        return type(self).__name__
+    def dumpPython(self, options=PrintOptions()):
+        specialImportRegistry.registerUse(self)
+        result = self.__class__.__name__+"(" # not including cms. since the deriving classes are not in cms "namespace"
+        options.indent()
+        res = self.dumpPythonImpl(options)
+        options.unindent()
+        if len(res) > 0:
+            result += "\n"+res+"\n"
+        result += ")\n"
+        return result
+
+    # The following methods are hooks to be overridden (if needed) in the deriving class
+    def dumpPythonImpl(self, options):
+        """Override if need to add any 'body' content to dumpPython(). Returns a string."""
+        return ""
+    def labels(self):
+        """Override to return a list of strings for the accelerator labels."""
+        return []
+    def enabledLabels(self):
+        """Override to return a list of strings for the accelerator labels
+        that are enabled in the system the job is being run on."""
+        return []
+    def apply(self, process, accelerators):
+        """Override if need to customize the Process at worker node. The
+        selected available accelerator labels are given in the
+        'accelerators' argument (the patterns, e.g. '*' have been
+        expanded to concrete labels).
+
+        This function may touch only untracked parameters.
+        """
+        pass
+
+class ProcessForProcessAccelerator(object):
+    """This class is inteded to wrap the Process object to constrain the
+    available functionality for ProcessAccelerator.apply()"""
+    def  __init__(self, process):
+        self.__process = process
+    def __getattr__(self, label):
+        value = getattr(self.__process, label)
+        if not isinstance(value, Service):
+            raise TypeError("ProcessAccelerator.apply() can get only Services. Tried to get {} with label {}".format(str(type(value)), label))
+        return value
+    def __setattr__(self, label, value):
+        if label == "_ProcessForProcessAccelerator__process":
+            super().__setattr__(label, value)
+        else:
+            if not isinstance(value, Service):
+                raise TypeError("ProcessAccelerator.apply() can only set Services. Tried to set {} with label {}".format(str(type(value)), label))
+            setattr(self.__process, label, value)
+    def add_(self, value):
+        if not isinstance(value, Service):
+            raise TypeError("ProcessAccelerator.apply() can only add Services. Tried to set {} with label {}".format(str(type(value)), label))
+        self.__process.add_(value)
+
+# Need to be a module-level function for the configuration with a
+# SwitchProducer to be pickleable.
+def _switchproducer_test2_case1(accelerators):
+    return ("test1" in accelerators, -10)
+def _switchproducer_test2_case2(accelerators):
+    return ("test2" in accelerators, -9)
+
 if __name__=="__main__":
     import unittest
     import copy
@@ -1918,12 +2053,65 @@ if __name__=="__main__":
         def __init__(self, **kargs):
             super(SwitchProducerTest,self).__init__(
                 dict(
-                    test1 = lambda: (True, -10),
-                    test2 = lambda: (True, -9),
-                    test3 = lambda: (True, -8),
-                    test4 = lambda: (True, -7)
+                    test1 = lambda accelerators: (True, -10),
+                    test2 = lambda accelerators: (True, -9),
+                    test3 = lambda accelerators: (True, -8),
+                    test4 = lambda accelerators: (True, -7)
                 ), **kargs)
     specialImportRegistry.registerSpecialImportForType(SwitchProducerTest, "from test import SwitchProducerTest")
+
+    class SwitchProducerTest2(SwitchProducer):
+        def __init__(self, **kargs):
+            super(SwitchProducerTest2,self).__init__(
+                dict(
+                    test1 = _switchproducer_test2_case1,
+                    test2 = _switchproducer_test2_case2,
+                ), **kargs)
+    specialImportRegistry.registerSpecialImportForType(SwitchProducerTest2, "from test import SwitchProducerTest2")
+
+    class ProcessAcceleratorTest(ProcessAccelerator):
+        def __init__(self, enabled=["test1", "test2", "anothertest3"]):
+            super(ProcessAcceleratorTest,self).__init__()
+            self._labels = ["test1", "test2", "anothertest3"]
+            self.setEnabled(enabled)
+        def setEnabled(self, enabled):
+            invalid = set(enabled).difference(set(self._labels))
+            if len(invalid) > 0:
+                raise Exception("Tried to enabled nonexistent test accelerators {}".format(",".join(invalid)))
+            self._enabled = enabled[:]
+        def dumpPythonImpl(self,options):
+            result = "{}enabled = [{}]".format(options.indentation(),
+                                               ", ".join(["'{}'".format(e) for e in self._enabled]))
+            return result
+        def labels(self):
+            return self._labels
+        def enabledLabels(self):
+            return self._enabled
+        def apply(self, process, accelerators):
+            process.AcceleratorTestService = Service("AcceleratorTestService")
+    specialImportRegistry.registerSpecialImportForType(ProcessAcceleratorTest, "from test import ProcessAcceleratorTest")
+
+    class ProcessAcceleratorTest2(ProcessAccelerator):
+        def __init__(self, enabled=["anothertest3", "anothertest4"]):
+            super(ProcessAcceleratorTest2,self).__init__()
+            self._labels = ["anothertest3", "anothertest4"]
+            self.setEnabled(enabled)
+        def setEnabled(self, enabled):
+            invalid = set(enabled).difference(set(self._labels))
+            if len(invalid) > 0:
+                raise Exception("Tried to enabled nonexistent test accelerators {}".format(",".join(invalid)))
+            self._enabled = enabled[:]
+        def dumpPythonImpl(self,options):
+            result = "{}enabled = [{}]".format(options.indentation(),
+                                               ", ".join(["'{}'".format(e) for e in self._enabled]))
+            return result
+        def labels(self):
+            return self._labels
+        def enabledLabels(self):
+            return self._enabled
+        def apply(self, process, accelerators):
+            pass
+    specialImportRegistry.registerSpecialImportForType(ProcessAcceleratorTest2, "from test import ProcessAcceleratorTest2")
 
     class TestModuleCommand(unittest.TestCase):
         def setUp(self):
@@ -2101,6 +2289,7 @@ process.options = cms.untracked.PSet(
     IgnoreCompletely = cms.untracked.vstring(),
     Rethrow = cms.untracked.vstring(),
     SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
     allowUnscheduled = cms.obsolete.untracked.bool,
     canDeleteEarly = cms.untracked.vstring(),
     deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
@@ -2719,10 +2908,10 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertRaises(TypeError,FinalPath,p.es)
 
             t = FinalPath()
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.FinalPath()\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.FinalPath()\n')
 
             t = FinalPath(p.a)
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.FinalPath(process.a)\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.FinalPath(process.a)\n')
 
             self.assertRaises(TypeError, FinalPath, Task())
             self.assertRaises(TypeError, FinalPath, p.a, Task())
@@ -2730,6 +2919,11 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             p.prod = EDProducer("prodName")
             p.t1 = Task(p.prod)
             self.assertRaises(TypeError, FinalPath, p.a, p.t1, Task(), p.t1)
+            
+            p.t = FinalPath(p.a)
+            p.a = OutputModule("ReplacedOutputModule")
+            self.assertEqual(p.t.dumpPython(PrintOptions()), 'cms.FinalPath(process.a)\n')
+            
         def testCloneSequence(self):
             p = Process("test")
             a = EDAnalyzer("MyAnalyzer")
@@ -3776,5 +3970,247 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             p = Process('PROCESS')
             p.extend(f)
             self.assertTrue(hasattr(p,'fltr'))
+        def testProcessForProcessAccelerator(self):
+            proc = Process("TEST")
+            p = ProcessForProcessAccelerator(proc)
+            p.TestService = Service("TestService")
+            self.assertTrue(hasattr(proc, "TestService"))
+            self.assertEqual(proc.TestService.type_(), "TestService")
+            self.assertRaises(TypeError, setattr, p, "a", EDProducer("Foo"))
+            p.add_(Service("TestServiceTwo"))
+            self.assertTrue(hasattr(proc, "TestServiceTwo"))
+            self.assertEqual(proc.TestServiceTwo.type_(), "TestServiceTwo")
+            p.TestService.foo = untracked.uint32(42)
+            self.assertEqual(proc.TestService.foo.value(), 42)
+            proc.mod = EDProducer("Producer")
+            self.assertRaises(TypeError, getattr, p, "mod")
+        def testProcessAccelerator(self):
+            proc = Process("TEST")
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertTrue(["cpu"], p.values["@available_accelerators"][1])
+            self.assertFalse(p.values["@selected_accelerators"][0])
+            self.assertTrue(["cpu"], p.values["@selected_accelerators"][1])
+
+            proc = Process("TEST")
+            self.assertRaises(TypeError, setattr, proc, "processAcceleratorTest", ProcessAcceleratorTest())
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            del proc.MessageLogger # remove boilerplate unnecessary for this test case
+            self.assertEqual(proc.dumpPython(),
+"""import FWCore.ParameterSet.Config as cms
+from test import ProcessAcceleratorTest
+
+process = cms.Process("TEST")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.optional.untracked.int32,
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+process.maxLuminosityBlocks = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.options = cms.untracked.PSet(
+    FailPath = cms.untracked.vstring(),
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    SkipEvent = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+process.ProcessAcceleratorTest = ProcessAcceleratorTest(
+    enabled = ['test1', 'test2', 'anothertest3']
+)
+
+
+""")
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["*"], p.values["options"][1].values["accelerators"][1])
+            self.assertFalse(p.values["options"][1].values["accelerators"][0])
+            self.assertTrue(["anothertest3", "cpu", "test1", "test2"], p.values["@selected_accelerators"][1])
+            self.assertEqual("AcceleratorTestService", p.values["services"][1][0].values["@service_type"][1])
+            self.assertFalse(p.values["@available_accelerators"][0])
+            self.assertTrue(["anothertest3", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest(enabled=["test1"])
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["cpu", "test1"], p.values["@selected_accelerators"][1])
+            self.assertEqual(["cpu", "test1"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["test2"]
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["test2"], p.values["@selected_accelerators"][1])
+            self.assertEqual(["anothertest3", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["test*"]
+            proc.fillProcessDesc(p)
+            self.assertEqual(["test1", "test2"], p.values["@selected_accelerators"][1])
+            self.assertEqual(["anothertest3", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest(enabled=["test1"])
+            proc.options.accelerators = ["test2"]
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual([], p.values["@selected_accelerators"][1])
+            self.assertEqual(["cpu", "test1"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["cpu*"]
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["cpu"], p.values["@selected_accelerators"][1])
+            self.assertEqual(["anothertest3", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["test3"]
+            p = TestMakePSet()
+            self.assertRaises(ValueError, proc.fillProcessDesc, p)
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["*", "test1"]
+            p = TestMakePSet()
+            self.assertRaises(ValueError, proc.fillProcessDesc, p)
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.ProcessAcceleratorTest2 = ProcessAcceleratorTest2()
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["anothertest3", "anothertest4", "cpu", "test1", "test2"], p.values["@selected_accelerators"][1])
+            self.assertEqual(["anothertest3", "anothertest4", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.ProcessAcceleratorTest2 = ProcessAcceleratorTest2()
+            proc.options.accelerators = ["*test3", "c*"]
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["anothertest3", "cpu"], p.values["@selected_accelerators"][1])
+            self.assertEqual(["anothertest3", "anothertest4", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.sp = SwitchProducerTest2(test2 = EDProducer("Foo",
+                                                             a = int32(1),
+                                                             b = PSet(c = int32(2))),
+                                          test1 = EDProducer("Bar",
+                                                             aa = int32(11),
+                                                             bb = PSet(cc = int32(12))))
+            proc.p = Path(proc.sp)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual((False, "sp@test2"), p.values["sp"][1].values["@chosen_case"])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest(enabled=["test1"])
+            proc.sp = SwitchProducerTest2(test2 = EDProducer("Foo",
+                                                             a = int32(1),
+                                                             b = PSet(c = int32(2))),
+                                          test1 = EDProducer("Bar",
+                                                             aa = int32(11),
+                                                             bb = PSet(cc = int32(12))))
+            proc.p = Path(proc.sp)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual((False, "sp@test1"), p.values["sp"][1].values["@chosen_case"])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["test1"]
+            proc.sp = SwitchProducerTest2(test2 = EDProducer("Foo",
+                                                             a = int32(1),
+                                                             b = PSet(c = int32(2))),
+                                          test1 = EDProducer("Bar",
+                                                             aa = int32(11),
+                                                             bb = PSet(cc = int32(12))))
+            proc.p = Path(proc.sp)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual((False, "sp@test1"), p.values["sp"][1].values["@chosen_case"])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["test*"]
+            proc.sp = SwitchProducerTest2(test2 = EDProducer("Foo",
+                                                             a = int32(1),
+                                                             b = PSet(c = int32(2))),
+                                          test1 = EDProducer("Bar",
+                                                             aa = int32(11),
+                                                             bb = PSet(cc = int32(12))))
+            proc.p = Path(proc.sp)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual((False, "sp@test2"), p.values["sp"][1].values["@chosen_case"])
+
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.options.accelerators = ["anothertest3"]
+            proc.sp = SwitchProducerTest2(test2 = EDProducer("Foo",
+                                                             a = int32(1),
+                                                             b = PSet(c = int32(2))),
+                                          test1 = EDProducer("Bar",
+                                                             aa = int32(11),
+                                                             bb = PSet(cc = int32(12))))
+            proc.p = Path(proc.sp)
+            p = TestMakePSet()
+            self.assertRaises(RuntimeError, proc.fillProcessDesc, p)
+
+            import pickle
+            proc = Process("TEST")
+            proc.ProcessAcceleratorTest = ProcessAcceleratorTest()
+            proc.sp = SwitchProducerTest2(test2 = EDProducer("Foo",
+                                                             a = int32(1),
+                                                             b = PSet(c = int32(2))),
+                                          test1 = EDProducer("Bar",
+                                                             aa = int32(11),
+                                                             bb = PSet(cc = int32(12))))
+            proc.p = Path(proc.sp)
+            pkl = pickle.dumps(proc)
+            unpkl = pickle.loads(pkl)
+            p = TestMakePSet()
+            unpkl.fillProcessDesc(p)
+            self.assertEqual((False, "sp@test2"), p.values["sp"][1].values["@chosen_case"])
+            self.assertEqual(["anothertest3", "cpu", "test1", "test2"], p.values["@available_accelerators"][1])
+            unpkl = pickle.loads(pkl)
+            unpkl.ProcessAcceleratorTest.setEnabled(["test1"])
+            p = TestMakePSet()
+            unpkl.fillProcessDesc(p)
+            self.assertEqual((False, "sp@test1"), p.values["sp"][1].values["@chosen_case"])
+            self.assertEqual(["cpu", "test1"], p.values["@available_accelerators"][1])
 
     unittest.main()

--- a/python/FWCore/ParameterSet/Mixins.py
+++ b/python/FWCore/ParameterSet/Mixins.py
@@ -219,7 +219,6 @@ class _Parameterizable(object):
             return getattr(self, params, None)
         for param in params:
             lastParam = getattr(lastParam, param, None)
-            print(str(lastParam))
             if lastParam == None:
                 return None
         return lastParam

--- a/python/FWCore/ParameterSet/Modules.py
+++ b/python/FWCore/ParameterSet/Modules.py
@@ -214,7 +214,7 @@ class Looper(_ConfigureComponent,_TypedParameterizable):
 
 # Need to be a module-level function for the configuration with a
 # SwitchProducer to be pickleable.
-def _switch_cpu():
+def _switch_cpu(accelerators):
     return (True, 1)
 
 class SwitchProducer(EDProducer):
@@ -257,21 +257,21 @@ class SwitchProducer(EDProducer):
         """Returns a function that returns the priority for a CPU "computing device". Intended to be used by deriving classes."""
         return _switch_cpu
 
-    def _chooseCase(self):
+    def _chooseCase(self, accelerators):
         """Returns the name of the chosen case."""
         cases = self.parameterNames_()
         bestCase = None
         for case in cases:
-            (enabled, priority) = self._caseFunctionDict[case]()
+            (enabled, priority) = self._caseFunctionDict[case](accelerators)
             if enabled and (bestCase is None or bestCase[0] < priority):
                 bestCase = (priority, case)
         if bestCase is None:
             raise RuntimeError("All cases '%s' were disabled" % (str(cases)))
         return bestCase[1]
 
-    def _getProducer(self):
+    def _getProducer(self, accelerators):
         """Returns the EDroducer of the chosen case"""
-        return self.__dict__[self._chooseCase()]
+        return self.__dict__[self._chooseCase(accelerators)]
 
     @staticmethod
     def __typeIsValid(typ):
@@ -378,7 +378,7 @@ class SwitchProducer(EDProducer):
             else:
                 modules.append(self.caseLabel_(myname, case))
 
-    def insertInto(self, parameterSet, myname):
+    def insertInto(self, parameterSet, myname, accelerators):
         for case in self.parameterNames_():
             producer = self.__dict__[case]
             producer.insertInto(parameterSet, self.caseLabel_(myname, case))
@@ -387,7 +387,7 @@ class SwitchProducer(EDProducer):
         newpset.addString(True, "@module_type", "SwitchProducer")
         newpset.addString(True, "@module_edm_type", "EDProducer")
         newpset.addVString(True, "@all_cases", [myname+"@"+p for p in self.parameterNames_()])
-        newpset.addString(False, "@chosen_case", myname+"@"+self._chooseCase())
+        newpset.addString(False, "@chosen_case", myname+"@"+self._chooseCase(accelerators))
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
 
     def _placeImpl(self,name,proc):
@@ -423,23 +423,9 @@ if __name__ == "__main__":
         def __init__(self, **kargs):
             super(SwitchProducerTest,self).__init__(
                 dict(
-                    test1 = lambda: (True, -10),
-                    test2 = lambda: (True, -9),
-                    test3 = lambda: (True, -8)
-                ), **kargs)
-    class SwitchProducerTest1Dis(SwitchProducer):
-        def __init__(self, **kargs):
-            super(SwitchProducerTest1Dis,self).__init__(
-                dict(
-                    test1 = lambda: (False, -10),
-                    test2 = lambda: (True, -9)
-                ), **kargs)
-    class SwitchProducerTest2Dis(SwitchProducer):
-        def __init__(self, **kargs):
-            super(SwitchProducerTest2Dis,self).__init__(
-                dict(
-                    test1 = lambda: (True, -10),
-                    test2 = lambda: (False, -9)
+                    test1 = lambda accelerators: ("test1" in accelerators, -10),
+                    test2 = lambda accelerators: ("test2" in accelerators, -9),
+                    test3 = lambda accelerators: ("test3" in accelerators, -8)
                 ), **kargs)
     class SwitchProducerPickleable(SwitchProducer):
         def __init__(self, **kargs):
@@ -566,16 +552,14 @@ if __name__ == "__main__":
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = SwitchProducerTest(test1 = EDProducer("Foo"))))
 
             # Case decision
+            accelerators = ["test1", "test2", "test3"]
             sp = SwitchProducerTest(test1 = EDProducer("Foo"), test2 = EDProducer("Bar"))
-            self.assertEqual(sp._getProducer().type_(), "Bar")
-            sp = SwitchProducerTest1Dis(test1 = EDProducer("Foo"), test2 = EDProducer("Bar"))
-            self.assertEqual(sp._getProducer().type_(), "Bar")
-            sp = SwitchProducerTest2Dis(test1 = EDProducer("Foo"), test2 = EDProducer("Bar"))
-            self.assertEqual(sp._getProducer().type_(), "Foo")
+            self.assertEqual(sp._getProducer(["test1", "test2", "test3"]).type_(), "Bar")
+            self.assertEqual(sp._getProducer(["test2", "test3"]).type_(), "Bar")
+            self.assertEqual(sp._getProducer(["test1", "test3"]).type_(), "Foo")
             sp = SwitchProducerTest(test1 = EDProducer("Bar"))
-            self.assertEqual(sp._getProducer().type_(), "Bar")
-            sp = SwitchProducerTest1Dis(test1 = EDProducer("Bar"))
-            self.assertRaises(RuntimeError, sp._getProducer)
+            self.assertEqual(sp._getProducer(["test1", "test2", "test3"]).type_(), "Bar")
+            self.assertRaises(RuntimeError, sp._getProducer, ["test2", "test3"])
 
             # Mofications
             from .Types import int32, string, PSet
@@ -593,7 +577,7 @@ if __name__ == "__main__":
             self.assertEqual(cl.test2.type_(), "Bar")
             self.assertEqual(cl.test2.aa.value(), 11)
             self.assertEqual(cl.test2.bb.cc.value(), 12)
-            self.assertEqual(sp._getProducer().type_(), "Bar")
+            self.assertEqual(sp._getProducer(accelerators).type_(), "Bar")
             # Modify clone
             cl.test1.a = 3
             self.assertEqual(cl.test1.a.value(), 3)

--- a/python/FWCore/ParameterSet/OrderedSet.py
+++ b/python/FWCore/ParameterSet/OrderedSet.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 # Copied from URL http://code.activestate.com/recipes/576694-orderedset/
 # on 15 November 2016
 
-#import collections.abc
 try:
     import collections.abc as collections_abc
 except ImportError:
@@ -90,8 +89,15 @@ class OrderedSet(collections_abc.MutableSet):
 
             
 if __name__ == '__main__':
-    s = OrderedSet('abracadaba')
-    t = OrderedSet('simsalabim')
-    print((s | t))
-    print((s & t))
-    print(s - t)
+    import unittest
+    class TestModuleCommand(unittest.TestCase):
+        def setUp(self):
+            """Nothing to do """
+            pass
+        def testSetOperations(self):
+            s = OrderedSet('abracadaba')
+            t = OrderedSet('simsalabim')
+            self.assertEqual(str((s | t)), "OrderedSet(['a', 'b', 'r', 'c', 'd', 's', 'i', 'm', 'l'])")
+            self.assertEqual(str((s & t)), "OrderedSet(['a', 'b'])")
+            self.assertEqual(str(s - t),"OrderedSet(['r', 'c', 'd'])")
+    unittest.main()

--- a/python/FWCore/ParameterSet/SequenceTypes.py
+++ b/python/FWCore/ParameterSet/SequenceTypes.py
@@ -450,8 +450,9 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         self.visit(v)
         if v.didReplace():
             self._seq = v.result(self)[0]
-            self._tasks.clear()
-            self.associate(*v.result(self)[1])
+            if v.result(self)[1]:
+              self._tasks.clear()
+              self.associate(*v.result(self)[1])
         return v.didReplace()
     def _replaceIfHeldDirectly(self,original,replacement):
         """Only replaces an 'original' with 'replacement' if 'original' is directly held.
@@ -495,8 +496,9 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         self.visit(v)
         if v.didRemove():
             self._seq = v.result(self)[0]
-            self._tasks.clear()
-            self.associate(*v.result(self)[1])
+            if v.result(self)[1]:
+              self._tasks.clear()
+              self.associate(*v.result(self)[1])
         return v.didRemove()
     def resolve(self, processDict,keepIfCannotResolve=False):
         if self._seq is not None:
@@ -2103,6 +2105,13 @@ if __name__=="__main__":
             t3 = Task(m5)
             t2.replace(m2,t3)
             self.assertTrue(t2.dumpPython() == "cms.Task(process.m1, process.m3, process.m5)\n")
+            
+            fp = FinalPath()
+            fp.replace(m1,m2)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath()\n")
+            fp = FinalPath(m1)
+            fp.replace(m1,m2)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath(process.m2)\n")
 
         def testReplaceIfHeldDirectly(self):
             m1 = DummyModule("m1")
@@ -2330,6 +2339,12 @@ if __name__=="__main__":
             self.assertTrue(t3.dumpPython() == "cms.Task(process.m2)\n")
             t3.remove(m2)
             self.assertTrue(t3.dumpPython() == "cms.Task()\n")
+            fp = FinalPath(m1+m2)
+            fp.remove(m1)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath(process.m2)\n")
+            fp = FinalPath(m1)
+            fp.remove(m1)
+            self.assertEqual(fp.dumpPython(), "cms.FinalPath()\n")
 
         def testCopyAndExclude(self):
             a = DummyModule("a")

--- a/python/FWCore/ParameterSet/__init__.py
+++ b/python/FWCore/ParameterSet/__init__.py
@@ -1,3 +1,3 @@
 #Automatically created by SCRAM
 import os
-__path__.append(os.path.dirname(os.path.abspath(__file__).rsplit('/FWCore/ParameterSet/',1)[0])+'/cfipython/slc7_amd64_gcc900/FWCore/ParameterSet')
+__path__.append(os.path.dirname(os.path.abspath(__file__).rsplit('/FWCore/ParameterSet/',1)[0])+'/cfipython/slc7_amd64_gcc10/FWCore/ParameterSet')

--- a/python/HeterogeneousCore/CUDACore/ProcessAcceleratorCUDA.py
+++ b/python/HeterogeneousCore/CUDACore/ProcessAcceleratorCUDA.py
@@ -1,0 +1,30 @@
+import FWCore.ParameterSet.Config as cms
+
+import os
+
+class ProcessAcceleratorCUDA(cms.ProcessAccelerator):
+    def __init__(self):
+        super(ProcessAcceleratorCUDA,self).__init__()
+        self._label = "gpu-nvidia"
+    def labels(self):
+        return [self._label]
+    def enabledLabels(self):
+        enabled = (os.system("cudaIsEnabled") == 0)
+        if enabled:
+            return self.labels()
+        else:
+            return []
+    def apply(self, process, accelerators):
+        if not hasattr(process, "CUDAService"):
+            from HeterogeneousCore.CUDAServices.CUDAService_cfi import CUDAService
+            process.add_(CUDAService)
+
+        if not hasattr(process.MessageLogger, "CUDAService"):
+            process.MessageLogger.CUDAService = cms.untracked.PSet()
+
+        if self._label in accelerators:
+            process.CUDAService.enabled = True
+        else:
+            process.CUDAService.enabled = False
+            
+cms.specialImportRegistry.registerSpecialImportForType(ProcessAcceleratorCUDA, "from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA")

--- a/python/HeterogeneousCore/CUDACore/ProcessAcceleratorCUDA_cfi.py
+++ b/python/HeterogeneousCore/CUDACore/ProcessAcceleratorCUDA_cfi.py
@@ -1,0 +1,3 @@
+from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA as _ProcessAcceleratorCUDA
+
+ProcessAcceleratorCUDA = _ProcessAcceleratorCUDA()

--- a/python/HeterogeneousCore/CUDACore/SwitchProducerCUDA.py
+++ b/python/HeterogeneousCore/CUDACore/SwitchProducerCUDA.py
@@ -1,13 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-_cuda_enabled_cached = None
-
-def _switch_cuda():
-    global _cuda_enabled_cached
-    if _cuda_enabled_cached is None:
-        import os
-        _cuda_enabled_cached = (os.system("cudaIsEnabled") == 0)
-    return (_cuda_enabled_cached, 2)
+def _switch_cuda(useAccelerators):
+    have_gpu = ("gpu-nvidia" in useAccelerators)
+    return (have_gpu, 2)
 
 class SwitchProducerCUDA(cms.SwitchProducer):
     def __init__(self, **kargs):

--- a/src/conf/confdb.properties
+++ b/src/conf/confdb.properties
@@ -2,7 +2,7 @@
 #  ConfDB properties
 ###################################
 
-confdb.setupCount=13
+confdb.setupCount=16
 
 
 
@@ -112,3 +112,26 @@ confdb12.dbUser=cms_hlt_gdrdev_w
 confdb12.proxy=false
 
 
+confdb13.dbSetup=DAQ3 Val
+confdb13.dbType=oracle
+confdb13.dbHost=int2r-s.cern.ch
+confdb13.dbPort=10121
+confdb13.dbName=int2r_lb.cern.ch
+confdb13.dbUser=cms_hlt_gdr_w
+confdb13.proxy=false
+
+confdb14.dbSetup=DAQ3 Val (socks tunnel)
+confdb14.dbType=oracle
+confdb14.dbHost=10.16.2.179
+confdb14.dbPort=10121
+confdb14.dbName=int2r_lb.cern.ch
+confdb14.dbUser=cms_hlt_gdr_w
+confdb14.proxy=true
+
+confdb15.dbSetup=DAQ3 Val (direct tunnel)
+confdb15.dbType=oracle
+confdb15.dbHost=localhost
+confdb15.dbPort=10121
+confdb15.dbName=int2r_lb.cern.ch
+confdb15.dbUser=cms_hlt_gdr_w
+confdb15.proxy=false

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-02-05
+confdb.version=V03-03-00
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-02-04
+confdb.version=V03-02-05
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/converter/python/PythonConfigurationWriter.java
+++ b/src/confdb/converter/python/PythonConfigurationWriter.java
@@ -61,8 +61,7 @@ public class PythonConfigurationWriter implements IConfigurationWriter {
 		if(conf.switchProducerCount() > 0) {
 			ReleaseVersionInfo relVarInfo = new ReleaseVersionInfo(conf.releaseTag());
 			str.append("from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA\n");
-			if( relVarInfo.cycle()>=13  ||
-				(relVarInfo.cycle()==12 && relVarInfo.major()>=3)){
+			if( relVarInfo.geq(12,3,0,6)) {				
 				str.append("from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA\n\n");
 				strProcessLoads.append(object+"ProcessAcceleratorCUDA = ProcessAcceleratorCUDA()\n");
 			}

--- a/src/confdb/converter/python/PythonConfigurationWriter.java
+++ b/src/confdb/converter/python/PythonConfigurationWriter.java
@@ -56,21 +56,24 @@ public class PythonConfigurationWriter implements IConfigurationWriter {
 				+ converterEngine.getNewline());
 
 		str.append("import FWCore.ParameterSet.Config as cms\n\n");
-		if(conf.switchProducerCount() > 0) {
-			ReleaseVersionInfo relVarInfo = new ReleaseVersionInfo(conf.releaseTag());
-		    str.append("from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA\n\n");
-			if(relVarInfo.cycle()>=12 && relVarInfo.major()>=3){
-				str.append("from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA\nprocess.ProcessAcceleratorCUDA = ProcessAcceleratorCUDA()\n\n");
-			}
-		}
-
+		
 
 		String object = "";
 		if (writeProcess == WriteProcess.YES) {
 			object = "process.";
 			str.append("process = cms.Process( \"" + conf.processName() + "\" )\n");
-		} else
+		} else {
 			indent = "";
+		}
+
+		if(conf.switchProducerCount() > 0) {
+			ReleaseVersionInfo relVarInfo = new ReleaseVersionInfo(conf.releaseTag());
+			str.append("from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA\n\n");
+			if(relVarInfo.cycle()>=12 && relVarInfo.major()>=3){
+				str.append("from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA\n"+object+"ProcessAcceleratorCUDA = ProcessAcceleratorCUDA()\n\n");
+			}
+		}
+	
 
 		str.append("\n" + object + "HLTConfigVersion = cms.PSet(\n  tableName = cms.string('" + fullName + "')\n)\n\n");
 

--- a/src/confdb/converter/python/PythonConfigurationWriter.java
+++ b/src/confdb/converter/python/PythonConfigurationWriter.java
@@ -68,9 +68,9 @@ public class PythonConfigurationWriter implements IConfigurationWriter {
 
 		if(conf.switchProducerCount() > 0) {
 			ReleaseVersionInfo relVarInfo = new ReleaseVersionInfo(conf.releaseTag());
-			str.append("from HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA\n\n");
+			str.append("\nfrom HeterogeneousCore.CUDACore.SwitchProducerCUDA import SwitchProducerCUDA\n\n");
 			if(relVarInfo.cycle()>=12 && relVarInfo.major()>=3){
-				str.append("from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA\n"+object+"ProcessAcceleratorCUDA = ProcessAcceleratorCUDA()\n\n");
+				str.append("from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA\n"+object+"ProcessAcceleratorCUDA = ProcessAcceleratorCUDA()\n");
 			}
 		}
 	

--- a/src/confdb/data/Configuration.java
+++ b/src/confdb/data/Configuration.java
@@ -1,6 +1,8 @@
 package confdb.data;
 
+import java.util.List;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Collections;
 
@@ -68,6 +70,9 @@ public class Configuration implements IConfiguration {
 	/** list of blocks (always empty for Configuration!) */
 	private ArrayList<Block> blocks = new ArrayList<Block>();
 
+	public static List<String> reservedNames = Arrays.asList(
+		"ProcessAcceleratorCUDA","HLTConfigVersion","schedule"
+	);
 	//
 	// construction
 	//
@@ -421,9 +426,21 @@ public class Configuration implements IConfiguration {
 	}
 
 	/** check if a qualifier is unique */
-	public boolean isUniqueQualifier(String qualifier) {
+	public boolean isUniqueQualifier(String qualifier) {		
 		if (qualifier.length() == 0)
 			return false;
+		for (String s : reservedNames)
+			if(s.equals(qualifier))
+				return false;		
+		return nameNotInProcessObject(qualifier);
+	}
+	
+	/** check if a given name exists in the process object 
+	 * does not include reserved names, only currently existing ones
+	*/
+	public boolean nameNotInProcessObject(String qualifier) {
+		if (qualifier.length() == 0)
+			return true;
 		for (ESSourceInstance ess : essources)
 			if (ess.name().equals(qualifier))
 				return false;
@@ -456,6 +473,11 @@ public class Configuration implements IConfiguration {
 		while (itOM.hasNext())
 			if (itOM.next().name().equals(qualifier))
 				return false;
+		
+		Iterator<Parameter> globalPSetIt = psets.parameterIterator();
+		while(globalPSetIt.hasNext())			
+			if(globalPSetIt.next().name().equals(qualifier))
+				return false;
 
 		return true;
 	}
@@ -464,6 +486,9 @@ public class Configuration implements IConfiguration {
 	public boolean hasUniqueQualifier(Referencable referencable) {
 		if (referencable.name().length() == 0)
 			return false;
+		for (String s : reservedNames)
+			if(s.equals(referencable.name()))
+				return false;
 		for (ESSourceInstance ess : essources)
 			if (ess.name().equals(referencable.name()))
 				return false;
@@ -487,7 +512,7 @@ public class Configuration implements IConfiguration {
 				continue;
 			if (geda.name().equals(referencable.name()))
 				return false;
-		}
+		}		
 		for (SwitchProducer swp : switchproducers) {
 			if (swp == referencable)
 				continue;
@@ -520,6 +545,14 @@ public class Configuration implements IConfiguration {
 			if (t.name().equals(referencable.name()))
 				return false;
 		}
+
+		Iterator<Parameter> globalPSetIt = psets.parameterIterator();
+		while(globalPSetIt.hasNext()){			
+			if(globalPSetIt.next().name().equals(referencable.name())){
+				return false;
+			}
+		}
+
 		return true;
 	}
 

--- a/src/confdb/data/ReleaseVersionInfo.java
+++ b/src/confdb/data/ReleaseVersionInfo.java
@@ -17,6 +17,8 @@ public class ReleaseVersionInfo {
      * if the 5th entry is pre/patch version or the suffix without the additional
      * contraint that pre/patch format is pre<number> or patch<number>
      * 
+     * anything infront of CMSSW is ignored
+     * 
      */
     public ReleaseVersionInfo(String releaseTag) {
         if(!setValues(releaseTag)){
@@ -25,8 +27,17 @@ public class ReleaseVersionInfo {
     }
 
     private boolean setValues(String releaseTag){
-        String[] splitTag = releaseTag.split("_");
-        if(splitTag.length<=4) return false;
+        String releaseTagTrimmed = releaseTag;
+        if(!releaseTag.startsWith("CMSSW")){
+            int index = releaseTag.indexOf("CMSSW");
+            if(index!=-1){
+                releaseTagTrimmed = releaseTag.substring(index);
+            }
+        }
+
+        String[] splitTag = releaseTagTrimmed.split("_");
+        
+        if(splitTag.length<4) return false;
         if(!splitTag[0].equals("CMSSW")) return false;
 
         try {
@@ -37,13 +48,13 @@ public class ReleaseVersionInfo {
             }else{
                 minor = Integer.parseInt(splitTag[3]);
             }
-        } catch (NumberFormatException ex) {
-            return false;
+        } catch (NumberFormatException ex) {            
+            return false;            
         }
 
-        if(splitTag.length>4){
+        if(splitTag.length>4){            
             if(splitTag[4].startsWith("pre")){
-                try{
+                try{                    
                     prerel = Integer.parseInt(splitTag[4].substring(3));
                 } catch(NumberFormatException ex){
 
@@ -51,12 +62,14 @@ public class ReleaseVersionInfo {
             }
             if(splitTag[4].startsWith("patch")){
                 try{
-                    patch = Integer.parseInt(splitTag[4].substring(6));
+                    patch = Integer.parseInt(splitTag[4].substring(5));
                 } catch(NumberFormatException ex){
-
+                    
                 }
             }
         }
+        System.err.print("parsed "+releaseTag);
+        System.err.println("  "+cycle+" "+major+" "+minor+" pre "+prerel+" patch "+patch);
         return true;
 
     }

--- a/src/confdb/data/ReleaseVersionInfo.java
+++ b/src/confdb/data/ReleaseVersionInfo.java
@@ -98,7 +98,7 @@ public class ReleaseVersionInfo {
                 }else if(patch!=-1){
                     return this.patch!=null && this.patch>=patch;
                 }else{
-                    return true;
+                    return (this.patch != null || this.prerel == null);
                 }
             }
             else return false;

--- a/src/confdb/data/ReleaseVersionInfo.java
+++ b/src/confdb/data/ReleaseVersionInfo.java
@@ -12,6 +12,7 @@ public class ReleaseVersionInfo {
      * format expected CMSSW_<cycle>_<major>_<minor>_<preX/patchY>_<suffix>
      * 
      * cycle,major,minor are all ints except for minor which can be X which is for nightlies
+     * X currently resolves to -1 and is less than all minor versions
      * 
      * <pre/patch> and <suffix> are both optional and there is no way to know 
      * if the 5th entry is pre/patch version or the suffix without the additional
@@ -44,7 +45,7 @@ public class ReleaseVersionInfo {
             cycle = Integer.parseInt(splitTag[1]);
             major = Integer.parseInt(splitTag[2]);
             if (splitTag[3].equals("X")){ //for integration builds
-                minor = Integer.MAX_VALUE;
+                minor = -1;
             }else{
                 minor = Integer.parseInt(splitTag[3]);
             }
@@ -68,8 +69,8 @@ public class ReleaseVersionInfo {
                 }
             }
         }
-        System.err.print("parsed "+releaseTag);
-        System.err.println("  "+cycle+" "+major+" "+minor+" pre "+prerel+" patch "+patch);
+        //System.err.print("parsed "+releaseTag);
+        //System.err.println("  "+cycle+" "+major+" "+minor+" pre "+prerel+" patch "+patch+" ");
         return true;
 
     }
@@ -78,5 +79,54 @@ public class ReleaseVersionInfo {
     public Integer minor(){return minor;} 
     public Integer patch(){return patch;} 
     public Integer prerel(){return prerel;} 
+    /** 
+     * checks if a given release is >= the specified values
+     * 
+     * notes:
+     *  a prerel is below its minor version
+     *  a patch is above its minor version
+     *  a nightly (X) is undefined, defaults to above as have to do something  
+     */
+    public boolean geq(int cycle,int major,int minor,int prerel,int patch){
+        if(this.cycle > cycle) return true;
+        else if(this.cycle==cycle && this.major > major) return true;
+        else if(this.cycle==cycle && this.major == major) {
+            if(minor==-1 || this.minor>minor) return true;
+            else if(this.minor==minor){
+                if(prerel!=-1){
+                    return this.prerel==null || this.prerel >= prerel;                    
+                }else if(patch!=-1){
+                    return this.patch!=null && this.patch>=patch;
+                }else{
+                    return true;
+                }
+            }
+            else return false;
+        }
+        return false;
+    }
+    public boolean geq(int cycle,int major,int minor){
+        return geq(cycle,major,minor,-1,-1);
+    }          
+    public boolean geq(int cycle,int major,int minor,int prerel){
+        return geq(cycle,major,minor,prerel,-1);
+    }          
 
+    public boolean equals(int cycle,int major,int minor,int prerel,int patch){
+        if(this.cycle==cycle && this.major==major && this.minor==minor){
+            if(prerel==-1 && this.prerel==null){
+                if(patch==-1 && this.patch==null) return true;
+                else return this.patch!=null && this.patch==patch;
+            } return this.prerel!=null && this.prerel==prerel;
+        }
+        return false;
+    }
+    public boolean equals(int cycle,int major,int minor,int prerel){
+        return equals(cycle,major,minor,prerel,-1);
+    }
+    public boolean equals(int cycle,int major,int minor){
+        return equals(cycle,major,minor,-1,-1);
+    }
+    
+    
 } 

--- a/src/confdb/data/ReleaseVersionInfo.java
+++ b/src/confdb/data/ReleaseVersionInfo.java
@@ -117,7 +117,7 @@ public class ReleaseVersionInfo {
             if(prerel==-1 && this.prerel==null){
                 if(patch==-1 && this.patch==null) return true;
                 else return this.patch!=null && this.patch==patch;
-            } return this.prerel!=null && this.prerel==prerel;
+            } else return this.prerel!=null && this.prerel==prerel;
         }
         return false;
     }

--- a/src/confdb/data/ReleaseVersionInfo.java
+++ b/src/confdb/data/ReleaseVersionInfo.java
@@ -1,0 +1,69 @@
+package confdb.data;
+
+public class ReleaseVersionInfo {		
+    private Integer cycle = null;
+    private Integer major = null;
+    private Integer minor = null;
+    private Integer prerel = null;
+    private Integer patch = null;
+
+    /** parses a release tag CMSSW
+     * 
+     * format expected CMSSW_<cycle>_<major>_<minor>_<preX/patchY>_<suffix>
+     * 
+     * cycle,major,minor are all ints except for minor which can be X which is for nightlies
+     * 
+     * <pre/patch> and <suffix> are both optional and there is no way to know 
+     * if the 5th entry is pre/patch version or the suffix without the additional
+     * contraint that pre/patch format is pre<number> or patch<number>
+     * 
+     */
+    public ReleaseVersionInfo(String releaseTag) {
+        if(!setValues(releaseTag)){
+            throw new IllegalArgumentException("release tag "+releaseTag+" is not of format CMSSW_A_B_C where A,B, C are ints (although C can be X) and thus can not be parsed");
+        }
+    }
+
+    private boolean setValues(String releaseTag){
+        String[] splitTag = releaseTag.split("_");
+        if(splitTag.length<=4) return false;
+        if(!splitTag[0].equals("CMSSW")) return false;
+
+        try {
+            cycle = Integer.parseInt(splitTag[1]);
+            major = Integer.parseInt(splitTag[2]);
+            if (splitTag[3].equals("X")){ //for integration builds
+                minor = Integer.MAX_VALUE;
+            }else{
+                minor = Integer.parseInt(splitTag[3]);
+            }
+        } catch (NumberFormatException ex) {
+            return false;
+        }
+
+        if(splitTag.length>4){
+            if(splitTag[4].startsWith("pre")){
+                try{
+                    prerel = Integer.parseInt(splitTag[4].substring(3));
+                } catch(NumberFormatException ex){
+
+                }
+            }
+            if(splitTag[4].startsWith("patch")){
+                try{
+                    patch = Integer.parseInt(splitTag[4].substring(6));
+                } catch(NumberFormatException ex){
+
+                }
+            }
+        }
+        return true;
+
+    }
+    public Integer cycle(){return cycle;}
+    public Integer major(){return major;}
+    public Integer minor(){return minor;} 
+    public Integer patch(){return patch;} 
+    public Integer prerel(){return prerel;} 
+
+} 

--- a/src/confdb/gui/ConfigChecks.java
+++ b/src/confdb/gui/ConfigChecks.java
@@ -28,7 +28,8 @@ class ConfigChecks {
         checkDatasetPathPrescales(config, frame) &&
         checkStreamOutputPaths(config, frame) &&
         checkFinalPathContent(config, frame) &&
-        checkForExtraFinalPaths(config, frame);
+        checkForExtraFinalPaths(config, frame) && 
+        checkForReservedNames(config, frame);
 	}
 
     public static boolean checkUnassignedPaths(Configuration config, JFrame frame){
@@ -408,4 +409,29 @@ class ConfigChecks {
 
     }
 
+    static boolean checkForReservedNames(Configuration config, JFrame frame){        
+        ArrayList<String> errors = new ArrayList<String>();
+        for(String name : Configuration.reservedNames){
+            if(!config.nameNotInProcessObject(name)){
+                errors.add("reserved name \""+name+"\" is present in the config");
+            }
+        }
+        if(!errors.isEmpty()){
+            String errStr = new String();
+            for(String error : errors ){
+                errStr+="\n"+error;
+            }         
+            String msg = new String("The following reserved names are present in the configuration\nThese will be overriden by the python converter so please rename them.\n");
+			msg+=errStr;			
+			JTextArea textArea = new JTextArea(msg);
+			JScrollPane scrollPane = new JScrollPane(textArea);  
+			//textArea.setLineWrap(true);  
+			//textArea.setWrapStyleWord(true); 
+			textArea.setColumns(80);
+			textArea.setRows(Math.min(errors.size()+5,50));
+			JOptionPane.showMessageDialog(frame, scrollPane, "Invalid Config", JOptionPane.ERROR_MESSAGE);            
+            return false;
+        }
+        return true;
+    }
 }

--- a/src/confdb/gui/ConfigChecks.java
+++ b/src/confdb/gui/ConfigChecks.java
@@ -29,7 +29,8 @@ class ConfigChecks {
         checkStreamOutputPaths(config, frame) &&
         checkFinalPathContent(config, frame) &&
         checkForExtraFinalPaths(config, frame) && 
-        checkForReservedNames(config, frame);
+        checkForReservedNames(config, frame) &&
+        checkForInvalidDefaultPSCol(config, frame);
 	}
 
     public static boolean checkUnassignedPaths(Configuration config, JFrame frame){
@@ -433,5 +434,38 @@ class ConfigChecks {
             return false;
         }
         return true;
+    }
+
+    static boolean checkForInvalidDefaultPSCol(Configuration config, JFrame frame){
+
+        ServiceInstance psService = config.service("PrescaleService");
+		if (psService != null) {
+            VStringParameter colNames = (VStringParameter)psService.parameter("lvl1Labels","vstring");
+            StringParameter defaultLabel = (StringParameter)psService.parameter("lvl1DefaultLabel","string");
+            boolean defaultFound = false;
+            for(int colNr=0;colNr<colNames.vectorSize();colNr++){
+                if(defaultLabel.value().equals(colNames.value(colNr))){
+                    defaultFound=true;                    
+                    break;
+                }
+            }
+            if(!defaultFound){                      
+                String msg = new String("The default PS column \""+defaultLabel.value()+"\" does not exist.\nPlease set it to an available column.\n");
+                msg+="The available columns are:";
+                for(int colNr=0;colNr<colNames.vectorSize();colNr++){
+                    msg+="\n   "+colNames.value(colNr);
+                }
+                JTextArea textArea = new JTextArea(msg);
+                JScrollPane scrollPane = new JScrollPane(textArea);  
+                //textArea.setLineWrap(true);  
+                //textArea.setWrapStyleWord(true); 
+                textArea.setColumns(80);
+                textArea.setRows(Math.min(msg.split("\n").length+1,50));
+                JOptionPane.showMessageDialog(frame, scrollPane, "Invalid Config", JOptionPane.ERROR_MESSAGE);            
+                return false; 
+            }
+        }
+        return true;
+
     }
 }

--- a/src/confdb/gui/ConfigurationTreeActions.java
+++ b/src/confdb/gui/ConfigurationTreeActions.java
@@ -126,15 +126,20 @@ public class ConfigurationTreeActions {
 		Configuration config = (Configuration) model.getRoot();
 		TreePath treePath = tree.getSelectionPath();
 
-		config.insertPSet(pset);
+		if(config.isUniqueQualifier(pset.name())){
+			config.insertPSet(pset);
 
-		model.nodeInserted(model.psetsNode(), config.psetCount() - 1);
-		model.updateLevel1Nodes();
+			model.nodeInserted(model.psetsNode(), config.psetCount() - 1);
+			model.updateLevel1Nodes();
 
-		TreePath parentPath = (treePath.getPathCount() == 2) ? treePath : treePath.getParentPath();
-		tree.setSelectionPath(parentPath.pathByAddingChild(pset));
+			TreePath parentPath = (treePath.getPathCount() == 2) ? treePath : treePath.getParentPath();
+			tree.setSelectionPath(parentPath.pathByAddingChild(pset));
 
-		return true;
+			return true;
+		}else{
+			System.err.println("Global PSet name "+pset.name()+" is not unique, pset not added");
+			return false;
+		}
 	}
 
 	/** remove global pset */

--- a/src/confdb/gui/MenuBar.java
+++ b/src/confdb/gui/MenuBar.java
@@ -282,6 +282,7 @@ public class MenuBar {
 		toolMenuSmartRenamingItem = new JMenuItem(toolMenuSmartRenaming, KeyEvent.VK_N);
 		toolMenuSmartRenamingItem.setActionCommand(toolMenuSmartRenaming);
 		toolMenuSmartRenamingItem.addActionListener(listener);
+		toolMenu.add(toolMenuSmartRenamingItem);
 		toolMenuConvertToTasksItem = new JMenuItem(toolMenuConvertToTasks);
 		toolMenuConvertToTasksItem.setActionCommand(toolMenuConvertToTasks);
 		toolMenuConvertToTasksItem.addActionListener(listener);

--- a/src/confdb/gui/ToolBar.java
+++ b/src/confdb/gui/ToolBar.java
@@ -242,7 +242,7 @@ public class ToolBar {
 		jButtonSmartRenaming.setActionCommand(cmdSmartRenaming);
 		jButtonSmartRenaming.addActionListener(listener);
 		jButtonSmartRenaming.setToolTipText("Renaming paths/sequences/tasks/switchproducers/modules/edAliases");
-		jButtonSmartVersions.setIcon(new ImageIcon(getClass().getResource("/SearchReplaceIcon.png")));
+		jButtonSmartRenaming.setIcon(new ImageIcon(getClass().getResource("/SearchReplaceIcon.png")));
 		jToolBar.add(jButtonSmartRenaming);
 
 		jButtonEditPS.setActionCommand(cmdEditPS);


### PR DESCRIPTION
This PR  introduces a change in the python writer such that it now writes out 
```
from HeterogeneousCore.CUDACore.ProcessAcceleratorCUDA import ProcessAcceleratorCUDA
process.ProcessAcceleratorCUDA = ProcessAcceleratorCUDA()
```

to the configuration if the release template is equal to or higher than CMSSW_12_3_0
This is necessary to properly offload to the GPU starting from CMSSW_12_3_0.  

It also at the same time
  * adds the DAQ  dbs to the drop down
  * updates the included python modules to those in CMSSW_12_3_0
  * fixes the disappeared smart rename option
  * adds reserved names "schedule, ProcessAcceleratorCUDA, HLTConfigVersion" , which are overwritten by the python converter and thus having them in the menu is an error
    * existing configs with these names can be opened but not saved until the offending item is renamed/removed
  * global psets are now considered when considering if a name is unique and also have uniqueness enforced on them