### PR TITLE
Making Tasks conditional in `12_4_0`+ (and `12_5_0_pre2`+)  

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2022-05-19 Sam Harper
     * tag V03-04-00
-	* for configs with release template >=12_4_0_pre4 Task is now renamed ConditionalTask in python
+	* for configs with release template >=12_4_0_pre4 (except for 12_5_0_pre1) Task is now renamed
+	  ConditionalTask in python
 	* FWCore/ParameterSet updated to release CMSSW_12_4_0_pre4
 	* parser supports parsing both conditional and standard tasks (but parses them to the same 
 	  location their type is lost)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 2022-05-19 Sam Harper
     * tag V03-04-00
-	* for configs with release template >=12_4_0_pre4 (except for 12_5_0_pre1) Task is now renamed
+	* for configs with release template >=12_4_0 (except for 12_5_0_pre1) Task is now renamed
 	  ConditionalTask in python
 	* FWCore/ParameterSet updated to release CMSSW_12_4_0_pre4
 	* parser supports parsing both conditional and standard tasks (but parses them to the same 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-05-19 Sam Harper
+    * tag V03-04-00
+	* for configs with release template >=12_4_0_pre4 Task is now renamed ConcurentTask in python
+
 2022-04-19 Sam Harper
     * tag V03-03-00
 	* added DAQ3 Val DB to the DB options

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 2022-05-19 Sam Harper
     * tag V03-04-00
-	* for configs with release template >=12_4_0_pre4 Task is now renamed ConcurentTask in python
+	* for configs with release template >=12_4_0_pre4 Task is now renamed ConditionalTask in python
+	* FWCore/ParameterSet updated to release CMSSW_12_4_0_pre4
+	* parser supports parsing both conditional and standard tasks (but parses them to the same 
+	  location their type is lost)
 
 2022-04-19 Sam Harper
     * tag V03-03-00

--- a/python/FWCore/ParameterSet/Config.py
+++ b/python/FWCore/ParameterSet/Config.py
@@ -41,7 +41,7 @@ def checkImportPermission(minLevel = 2, allowedPatterns = []):
     import inspect
     import os
 
-    ignorePatterns = ['FWCore/ParameterSet/Config.py','<string>','<frozen ']
+    ignorePatterns = ['FWCore/ParameterSet/Config.py', 'FWCore/ParameterSet/python/Config.py','<string>','<frozen ']
     CMSSWPath = [os.environ['CMSSW_BASE'],os.environ['CMSSW_RELEASE_BASE']]
 
     # Filter the stack to things in CMSSWPath and not in ignorePatterns
@@ -101,6 +101,7 @@ def findProcess(module):
 
 class Process(object):
     """Root class for a CMS configuration process"""
+    _firstProcess = True
     def __init__(self,name,*Mods):
         """The argument 'name' will be the name applied to this Process
             Can optionally pass as additional arguments cms.Modifier instances
@@ -123,6 +124,7 @@ class Process(object):
         self.__dict__['_Process__finalpaths'] = DictTypes.SortedKeysDict() # of definition
         self.__dict__['_Process__sequences'] = {}
         self.__dict__['_Process__tasks'] = {}
+        self.__dict__['_Process__conditionaltasks'] = {}
         self.__dict__['_Process__services'] = {}
         self.__dict__['_Process__essources'] = {}
         self.__dict__['_Process__esproducers'] = {}
@@ -145,6 +147,13 @@ class Process(object):
         # FWCore.Message(Logger|Service).MessageLogger_cfi
         # use the very same MessageLogger object.
         self.MessageLogger = MessageLogger
+        if Process._firstProcess:
+            Process._firstProcess = False
+        else:
+            if len(Mods) > 0:
+                for m in self.__modifiers:
+                    if not m._isChosen():
+                        raise RuntimeError("The Process {} tried to redefine which Modifiers to use after another Process was already started".format(name))
         for m in self.__modifiers:
             m._setChosen()
 
@@ -304,6 +313,10 @@ class Process(object):
         """returns a dict of the tasks that have been added to the Process"""
         return DictTypes.FixedKeysDict(self.__tasks)
     tasks = property(tasks_,doc="dictionary containing the tasks for the process")
+    def conditionaltasks_(self):
+        """returns a dict of the conditionaltasks that have been added to the Process"""
+        return DictTypes.FixedKeysDict(self.__conditionaltasks)
+    conditionaltasks = property(conditionaltasks_,doc="dictionary containing the conditionatasks for the process")
     def schedule_(self):
         """returns the schedule that has been added to the Process or None if none have been added"""
         return self.__schedule
@@ -410,6 +423,9 @@ class Process(object):
                             +"an instance of "+str(type(value))+" will not work - requested label is "+name)
         if not isinstance(value,_Labelable) and not isinstance(value,Source) and not isinstance(value,Looper) and not isinstance(value,Schedule):
             if name == value.type_():
+                if hasattr(self,name) and (getattr(self,name)!=value):
+                    self._replaceInTasks(name, value)
+                    self._replaceInConditionalTasks(name, value)
                 # Only Services get handled here
                 self.add_(value)
                 return
@@ -446,6 +462,7 @@ class Process(object):
             if newValue._isTaskComponent():
                 if not self.__InExtendCall:
                     self._replaceInTasks(name, newValue)
+                    self._replaceInConditionalTasks(name, newValue)
                     self._replaceInSchedule(name, newValue)
                 else:
                     if not isinstance(newValue, Task):
@@ -464,8 +481,10 @@ class Process(object):
                         if s is not None:
                             raise ValueError(msg1+s.label_()+msg2)
 
-            if isinstance(newValue, _Sequenceable) or newValue._isTaskComponent():
+            if isinstance(newValue, _Sequenceable) or newValue._isTaskComponent() or isinstance(newValue, ConditionalTask):
                 if not self.__InExtendCall:
+                    if isinstance(newValue, ConditionalTask):
+                        self._replaceInConditionalTasks(name, newValue)
                     self._replaceInSequences(name, newValue)
                 else:
                     #should check to see if used in sequence before complaining
@@ -566,7 +585,7 @@ class Process(object):
         self._delHelper(name)
         obj = getattr(self,name)
         if not obj is None:
-            if not isinstance(obj, Sequence) and not isinstance(obj, Task):
+            if not isinstance(obj, Sequence) and not isinstance(obj, Task) and not isinstance(obj,ConditionalTask):
                 # For modules, ES modules and services we can also remove
                 # the deleted object from Sequences, Paths, EndPaths, and
                 # Tasks. Note that for Sequences and Tasks that cannot be done
@@ -578,6 +597,7 @@ class Process(object):
                 # has been checked that the deleted Sequence is not used).
                 if obj._isTaskComponent():
                     self._replaceInTasks(name, None)
+                    self._replaceInConditionalTasks(name, None)
                     self._replaceInSchedule(name, None)
                 if isinstance(obj, _Sequenceable) or obj._isTaskComponent():
                     self._replaceInSequences(name, None)
@@ -604,7 +624,6 @@ class Process(object):
             raise TypeError
         if not isinstance(value,_Unlabelable):
             raise TypeError
-        #clone the item
         #clone the item
         if self.__isStrict:
             newValue =value.copy()
@@ -685,6 +704,9 @@ class Process(object):
     def _placeTask(self,name,task):
         self._validateTask(task, name)
         self._place(name, task, self.__tasks)
+    def _placeConditionalTask(self,name,task):
+        self._validateConditionalTask(task, name)
+        self._place(name, task, self.__conditionaltasks)
     def _placeAlias(self,name,mod):
         self._place(name, mod, self.__aliases)
     def _placePSet(self,name,mod):
@@ -740,7 +762,7 @@ class Process(object):
                     self.__setattr__(name,item)
             elif isinstance(item,_ModuleSequenceType):
                 seqs[name]=item
-            elif isinstance(item,Task):
+            elif isinstance(item,Task) or isinstance(item, ConditionalTask):
                 tasksToAttach[name] = item
             elif isinstance(item,_Labelable):
                 self.__setattr__(name,item)
@@ -913,10 +935,18 @@ class Process(object):
             l = set()
             visitor = NodeNameVisitor(l)
             sequence.visit(visitor)
-        except:
-            raise RuntimeError("An entry in sequence "+label + ' has no label')
+        except Exception as e:
+            raise RuntimeError("An entry in sequence {} has no label\n  Seen entries: {}\n  Error: {}".format(label, l, e))
 
     def _validateTask(self, task, label):
+        # See if every module and service has been inserted into the process
+        try:
+            l = set()
+            visitor = NodeNameVisitor(l)
+            task.visit(visitor)
+        except:
+            raise RuntimeError("An entry in task " + label + ' has not been attached to the process')
+    def _validateConditionalTask(self, task, label):
         # See if every module and service has been inserted into the process
         try:
             l = set()
@@ -939,6 +969,8 @@ class Process(object):
             containedItems = []
             if isinstance(item, Task):
                 v = TaskVisitor(containedItems)
+            elif isinstance(item, ConditionalTask):
+                v = ConditionalTaskVisitor(containedItems)
             else:
                 v = SequenceVisitor(containedItems)
             try:
@@ -947,6 +979,9 @@ class Process(object):
                 if isinstance(item, Task):
                     raise RuntimeError("Failed in a Task visitor. Probably " \
                                        "a circular dependency discovered in Task with label " + label)
+                elif isinstance(item, ConditionalTask):
+                    raise RuntimeError("Failed in a ConditionalTask visitor. Probably " \
+                                       "a circular dependency discovered in ConditionalTask with label " + label)
                 else:
                     raise RuntimeError("Failed in a Sequence visitor. Probably a " \
                                        "circular dependency discovered in Sequence with label " + label)
@@ -961,6 +996,10 @@ class Process(object):
                     if testItem is None or containedItem != testItem:
                         if isinstance(item, Task):
                             raise RuntimeError("Task has a label, but using its label to get an attribute" \
+                                               " from the process yields a different object or None\n"+
+                                               "label = " + containedItem.label_())
+                        if isinstance(item, ConditionalTask):
+                            raise RuntimeError("ConditionalTask has a label, but using its label to get an attribute" \
                                                " from the process yields a different object or None\n"+
                                                "label = " + containedItem.label_())
                         else:
@@ -1017,6 +1056,7 @@ class Process(object):
         result+=self._dumpPythonList(self.es_sources_(), options)
         result+=self._dumpPython(self.es_prefers_(), options)
         result+=self._dumpPythonList(self._itemsInDependencyOrder(self.tasks), options)
+        result+=self._dumpPythonList(self._itemsInDependencyOrder(self.conditionaltasks), options)
         result+=self._dumpPythonList(self._itemsInDependencyOrder(self.sequences), options)
         result+=self._dumpPythonList(self.paths_(), options)
         result+=self._dumpPythonList(self.endpaths_(), options)
@@ -1121,6 +1161,10 @@ class Process(object):
     def _replaceInTasks(self, label, new):
         old = getattr(self,label)
         for task in self.tasks.values():
+            task.replace(old, new)
+    def _replaceInConditionalTasks(self, label, new):
+        old = getattr(self,label)
+        for task in self.conditionaltasks.values():
             task.replace(old, new)
     def _replaceInSchedule(self, label, new):
         if self.schedule_() == None:
@@ -1245,15 +1289,24 @@ class Process(object):
         endpathValidator = EndPathValidator()
         decoratedList = []
         lister = DecoratedNodeNameVisitor(decoratedList)
-        pathCompositeVisitor = CompositeVisitor(pathValidator, nodeVisitor, lister)
+        condTaskModules = []
+        condTaskVistor = ModuleNodeOnConditionalTaskVisitor(condTaskModules)
+        pathCompositeVisitor = CompositeVisitor(pathValidator, nodeVisitor, lister, condTaskVistor)
         endpathCompositeVisitor = CompositeVisitor(endpathValidator, nodeVisitor, lister)
         for triggername in triggerPaths:
             iPath = self.paths_()[triggername]
             iPath.resolve(self.__dict__)
             pathValidator.setLabel(triggername)
             lister.initialize()
+            condTaskModules[:] = []
             iPath.visit(pathCompositeVisitor)
-            iPath.insertInto(processPSet, triggername, decoratedList)
+            if condTaskModules:
+              decoratedList.append("#")
+              l = list({x.label_() for x in condTaskModules})
+              l.sort()
+              decoratedList.extend(l)
+              decoratedList.append("@")
+            iPath.insertInto(processPSet, triggername, decoratedList[:])
         for endpathname in endpaths:
             if endpathname is not endPathWithFinalPathModulesName:
               iEndPath = self.endpaths_()[endpathname]
@@ -1263,7 +1316,7 @@ class Process(object):
             endpathValidator.setLabel(endpathname)
             lister.initialize()
             iEndPath.visit(endpathCompositeVisitor)
-            iEndPath.insertInto(processPSet, endpathname, decoratedList)
+            iEndPath.insertInto(processPSet, endpathname, decoratedList[:])
         processPSet.addVString(False, "@filters_on_endpaths", endpathValidator.filtersOnEndpaths)
           
 
@@ -1785,6 +1838,8 @@ class Modifier(object):
             toObj._tasks = fromObj._tasks
         elif isinstance(fromObj,Task):
             toObj._collection = fromObj._collection
+        elif isinstance(fromObj,ConditionalTask):
+            toObj._collection = fromObj._collection
         elif isinstance(fromObj,_Parameterizable):
             #clear old items just incase fromObj is not a complete superset of toObj
             for p in toObj.parameterNames_():
@@ -2263,6 +2318,14 @@ if __name__=="__main__":
 
             p = Process('test')
             p.a = EDProducer("MyProducer")
+            p.t = ConditionalTask(p.a)
+            p.p = Path(p.t)
+            self.assertRaises(ValueError, p.extend, FromArg(a = EDProducer("YourProducer")))
+            self.assertRaises(ValueError, p.extend, FromArg(a = EDAlias()))
+            self.assertRaises(ValueError, p.__setattr__, "a", EDAlias())
+
+            p = Process('test')
+            p.a = EDProducer("MyProducer")
             p.s = Sequence(p.a)
             p.p = Path(p.s)
             self.assertRaises(ValueError, p.extend, FromArg(a = EDProducer("YourProducer")))
@@ -2497,6 +2560,41 @@ process.r = cms.Sequence((process.a))
 process.p = cms.Path(process.a)
 process.p2 = cms.Path(process.r, process.task1, process.task2)
 process.schedule = cms.Schedule(*[ process.p2, process.p ], tasks=[process.task3, process.task4, process.task5])""")
+            # include some conditional tasks
+            p = Process("test")
+            p.a = EDAnalyzer("MyAnalyzer")
+            p.b = EDProducer("bProducer")
+            p.c = EDProducer("cProducer")
+            p.d = EDProducer("dProducer")
+            p.e = EDProducer("eProducer")
+            p.f = EDProducer("fProducer")
+            p.g = EDProducer("gProducer")
+            p.task5 = Task()
+            p.task3 = Task()
+            p.task2 = ConditionalTask(p.c, p.task3)
+            p.task1 = ConditionalTask(p.task5)
+            p.p = Path(p.a)
+            s = Sequence(p.a)
+            p.r = Sequence(s)
+            p.p2 = Path(p.r, p.task1, p.task2)
+            p.schedule = Schedule(p.p2,p.p,tasks=[p.task5])
+            d=p.dumpPython()
+            self.assertEqual(_lineDiff(d,Process("test").dumpPython()),
+"""process.b = cms.EDProducer("bProducer")
+process.c = cms.EDProducer("cProducer")
+process.d = cms.EDProducer("dProducer")
+process.e = cms.EDProducer("eProducer")
+process.f = cms.EDProducer("fProducer")
+process.g = cms.EDProducer("gProducer")
+process.a = cms.EDAnalyzer("MyAnalyzer")
+process.task5 = cms.Task()
+process.task3 = cms.Task()
+process.task2 = cms.ConditionalTask(process.c, process.task3)
+process.task1 = cms.ConditionalTask(process.task5)
+process.r = cms.Sequence((process.a))
+process.p = cms.Path(process.a)
+process.p2 = cms.Path(process.r, process.task1, process.task2)
+process.schedule = cms.Schedule(*[ process.p2, process.p ], tasks=[process.task5])""")
             # only tasks
             p = Process("test")
             p.d = EDProducer("dProducer")
@@ -2565,12 +2663,13 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             t4 = Task(p.d)
             t5 = Task(p.d)
             t6 = Task(p.d)
+            p.ct1 = ConditionalTask(p.d)
             s = Sequence(p.a*p.b)
-            p.s4 = Sequence(p.a*p.b)
+            p.s4 = Sequence(p.a*p.b, p.ct1)
             s.associate(t2)
             p.s4.associate(t2)
             p.p = Path(p.c+s+p.a)
-            p.p2 = Path(p.c+p.s4+p.a)
+            p.p2 = Path(p.c+p.s4+p.a, p.ct1)
             p.e3 = EndPath(p.c+s+p.a)
             new = EDAnalyzer("NewAnalyzer")
             new2 = EDProducer("NewProducer")
@@ -2587,14 +2686,14 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             visitor_p2 = NodeVisitor()
             p.p2.visit(visitor_p2)
             self.assertTrue(visitor_p2.modules == set([new,new2,p.b,p.c]))
-            self.assertEqual(p.p2.dumpPython()[:-1], "cms.Path(process.c+process.s4+process.a)")
+            self.assertEqual(p.p2.dumpPython()[:-1], "cms.Path(process.c+process.s4+process.a, process.ct1)")
             visitor3 = NodeVisitor()
             p.e3.visit(visitor3)
             self.assertTrue(visitor3.modules == set([new,new2,p.b,p.c]))
             visitor4 = NodeVisitor()
             p.s4.visit(visitor4)
             self.assertTrue(visitor4.modules == set([new,new2,p.b]))
-            self.assertEqual(p.s4.dumpPython()[:-1],"cms.Sequence(process.a+process.b, cms.Task(process.d))")
+            self.assertEqual(p.s4.dumpPython()[:-1],"cms.Sequence(process.a+process.b, cms.Task(process.d), process.ct1)")
             visitor5 = NodeVisitor()
             p.t1.visit(visitor5)
             self.assertTrue(visitor5.modules == set([new2]))
@@ -2602,6 +2701,14 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             listOfTasks = list(p.schedule._tasks)
             listOfTasks[0].visit(visitor6)
             self.assertTrue(visitor6.modules == set([new2]))
+            visitor7 = NodeVisitor()
+            p.ct1.visit(visitor7)
+            self.assertTrue(visitor7.modules == set([new2]))
+            visitor8 = NodeVisitor()
+            listOfConditionalTasks = list(p.conditionaltasks.values())
+            listOfConditionalTasks[0].visit(visitor8)
+            self.assertTrue(visitor8.modules == set([new2]))
+
 
             p.d2 = EDProducer("YourProducer")
             p.schedule = Schedule(p.p, p.p2, p.e3, tasks=[p.t1])
@@ -2663,7 +2770,7 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             edproducer9 = EDProducer("b9")
             edfilter = EDFilter("c")
             service = Service("d")
-            service3 = Service("d")
+            service3 = Service("d", v = untracked.uint32(3))
             essource = ESSource("e")
             esproducer = ESProducer("f")
             testTask2 = Task()
@@ -2848,6 +2955,193 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             process.path200.replace(process.g,process.e)
             self.assertEqual(process.path200.dumpPython(), "cms.EndPath(process.c, cms.Task(process.e))\n")
 
+        def testConditionalTask(self):
+
+            # create some objects to use in tests
+            edanalyzer = EDAnalyzer("a")
+            edproducer = EDProducer("b")
+            edproducer2 = EDProducer("b2")
+            edproducer3 = EDProducer("b3")
+            edproducer4 = EDProducer("b4")
+            edproducer8 = EDProducer("b8")
+            edproducer9 = EDProducer("b9")
+            edfilter = EDFilter("c")
+            service = Service("d")
+            service3 = Service("d", v = untracked.uint32(3))
+            essource = ESSource("e")
+            esproducer = ESProducer("f")
+            testTask2 = Task()
+            testCTask2 = ConditionalTask()
+
+            # test adding things to Tasks
+            testTask1 = ConditionalTask(edproducer, edfilter)
+            self.assertRaises(RuntimeError, testTask1.add, edanalyzer)
+            testTask1.add(essource, service)
+            testTask1.add(essource, esproducer)
+            testTask1.add(testTask2)
+            testTask1.add(testCTask2)
+            coll = testTask1._collection
+            self.assertTrue(edproducer in coll)
+            self.assertTrue(edfilter in coll)
+            self.assertTrue(service in coll)
+            self.assertTrue(essource in coll)
+            self.assertTrue(esproducer in coll)
+            self.assertTrue(testTask2 in coll)
+            self.assertTrue(testCTask2 in coll)
+            self.assertTrue(len(coll) == 7)
+            self.assertTrue(len(testTask2._collection) == 0)
+
+            taskContents = []
+            for i in testTask1:
+                taskContents.append(i)
+            self.assertEqual(taskContents, [edproducer, edfilter, essource, service, esproducer, testTask2, testCTask2])
+
+            # test attaching Task to Process
+            process = Process("test")
+
+            process.mproducer = edproducer
+            process.mproducer2 = edproducer2
+            process.mfilter = edfilter
+            process.messource = essource
+            process.mesproducer = esproducer
+            process.d = service
+
+            testTask3 = ConditionalTask(edproducer, edproducer2)
+            testTask1.add(testTask3)
+            process.myTask1 = testTask1
+
+            # test the validation that occurs when attaching a ConditionalTask to a Process
+            # first a case that passes, then one the fails on an EDProducer
+            # then one that fails on a service
+            l = set()
+            visitor = NodeNameVisitor(l)
+            testTask1.visit(visitor)
+            self.assertEqual(l, set(['mesproducer', 'mproducer', 'mproducer2', 'mfilter', 'd', 'messource']))
+            l2 = testTask1.moduleNames()
+            self.assertEqual(l2, set(['mesproducer', 'mproducer', 'mproducer2', 'mfilter', 'd', 'messource']))
+
+            testTask4 = ConditionalTask(edproducer3)
+            l.clear()
+            self.assertRaises(RuntimeError, testTask4.visit, visitor)
+            try:
+                process.myTask4 = testTask4
+                self.assertTrue(False)
+            except RuntimeError:
+                pass
+
+            testTask5 = ConditionalTask(service3)
+            l.clear()
+            self.assertRaises(RuntimeError, testTask5.visit, visitor)
+            try:
+                process.myTask5 = testTask5
+                self.assertTrue(False)
+            except RuntimeError:
+                pass
+
+            process.d = service3
+            process.myTask5 = testTask5
+
+            # test placement into the Process and the tasks property
+            expectedDict = { 'myTask1' : testTask1, 'myTask5' : testTask5 }
+            expectedFixedDict = DictTypes.FixedKeysDict(expectedDict);
+            self.assertEqual(process.conditionaltasks, expectedFixedDict)
+            self.assertEqual(process.conditionaltasks['myTask1'], testTask1)
+            self.assertEqual(process.myTask1, testTask1)
+
+            # test replacing an EDProducer in a ConditionalTask when calling __settattr__
+            # for the EDProducer on the Process.
+            process.mproducer2 = edproducer4
+            process.d = service
+            l = list()
+            visitor1 = ModuleNodeVisitor(l)
+            testTask1.visit(visitor1)
+            l.sort(key=lambda mod: mod.__str__())
+            expectedList = sorted([edproducer,essource,esproducer,service,edfilter,edproducer,edproducer4],key=lambda mod: mod.__str__())
+            self.assertEqual(expectedList, l)
+            process.myTask6 = ConditionalTask()
+            process.myTask7 = ConditionalTask()
+            process.mproducer8 = edproducer8
+            process.myTask8 = ConditionalTask(process.mproducer8)
+            process.myTask6.add(process.myTask7)
+            process.myTask7.add(process.myTask8)
+            process.myTask1.add(process.myTask6)
+            process.myTask8.add(process.myTask5)
+            self.assertEqual(process.myTask8.dumpPython(), "cms.ConditionalTask(process.mproducer8, process.myTask5)\n")
+
+            testDict = process._itemsInDependencyOrder(process.conditionaltasks)
+            expectedLabels = ["myTask5", "myTask8", "myTask7", "myTask6", "myTask1"]
+            expectedTasks = [process.myTask5, process.myTask8, process.myTask7, process.myTask6, process.myTask1]
+            index = 0
+            for testLabel, testTask in testDict.items():
+                self.assertEqual(testLabel, expectedLabels[index])
+                self.assertEqual(testTask, expectedTasks[index])
+                index += 1
+
+            pythonDump = testTask1.dumpPython(PrintOptions())
+
+
+            expectedPythonDump = 'cms.ConditionalTask(process.d, process.mesproducer, process.messource, process.mfilter, process.mproducer, process.mproducer2, process.myTask6)\n'
+            self.assertEqual(pythonDump, expectedPythonDump)
+
+            process.myTask5 = ConditionalTask()
+            self.assertEqual(process.myTask8.dumpPython(), "cms.ConditionalTask(process.mproducer8, process.myTask5)\n")
+            process.myTask100 = ConditionalTask()
+            process.mproducer9 = edproducer9
+            sequence1 = Sequence(process.mproducer8, process.myTask1, process.myTask5, testTask2, testTask3)
+            sequence2 = Sequence(process.mproducer8 + process.mproducer9)
+            process.sequence3 = Sequence((process.mproducer8 + process.mfilter))
+            sequence4 = Sequence()
+            process.path1 = Path(process.mproducer+process.mproducer8+sequence1+sequence2+process.sequence3+sequence4)
+            process.path1.associate(process.myTask1, process.myTask5, testTask2, testTask3)
+            process.path11 = Path(process.mproducer+process.mproducer8+sequence1+sequence2+process.sequence3+ sequence4,process.myTask1, process.myTask5, testTask2, testTask3, process.myTask100)
+            process.path2 = Path(process.mproducer)
+            process.path3 = Path(process.mproducer9+process.mproducer8,testTask2)
+
+            self.assertEqual(process.path1.dumpPython(PrintOptions()), 'cms.Path(process.mproducer+process.mproducer8+cms.Sequence(process.mproducer8, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)\n')
+
+            self.assertEqual(process.path11.dumpPython(PrintOptions()), 'cms.Path(process.mproducer+process.mproducer8+cms.Sequence(process.mproducer8, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask100, process.myTask5)\n')
+
+            # test NodeNameVisitor and moduleNames
+            l = set()
+            nameVisitor = NodeNameVisitor(l)
+            process.path1.visit(nameVisitor)
+            self.assertTrue(l == set(['mproducer', 'd', 'mesproducer', None, 'mproducer9', 'mproducer8', 'messource', 'mproducer2', 'mfilter']))
+            self.assertTrue(process.path1.moduleNames() == set(['mproducer', 'd', 'mesproducer', None, 'mproducer9', 'mproducer8', 'messource', 'mproducer2', 'mfilter']))
+
+            # test copy
+            process.mproducer10 = EDProducer("b10")
+            process.path21 = process.path11.copy()
+            process.path21.replace(process.mproducer, process.mproducer10)
+
+            self.assertEqual(process.path11.dumpPython(PrintOptions()), 'cms.Path(process.mproducer+process.mproducer8+cms.Sequence(process.mproducer8, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask5)+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer), cms.Task(), process.myTask1, process.myTask100, process.myTask5)\n')
+
+            # Some peculiarities of the way things work show up here. dumpPython sorts tasks and
+            # removes duplication at the level of strings. The Task and Sequence objects themselves
+            # remove duplicate tasks in their contents if the instances are the same (exact same python
+            # object id which is not the same as the string representation being the same).
+            # Also note that the mutating visitor replaces sequences and tasks that have
+            # modified contents with their modified contents, it does not modify the sequence
+            # or task itself.
+            self.assertEqual(process.path21.dumpPython(PrintOptions()), 'cms.Path(process.mproducer10+process.mproducer8+process.mproducer8+(process.mproducer8+process.mproducer9)+process.sequence3, cms.ConditionalTask(process.None, process.mproducer10), cms.ConditionalTask(process.d, process.mesproducer, process.messource, process.mfilter, process.mproducer10, process.mproducer2, process.mproducer8, process.myTask5), cms.Task(), process.myTask100, process.myTask5)\n')
+
+            process.path22 = process.path21.copyAndExclude([process.d, process.mesproducer, process.mfilter])
+            self.assertEqual(process.path22.dumpPython(PrintOptions()), 'cms.Path(process.mproducer10+process.mproducer8+process.mproducer8+(process.mproducer8+process.mproducer9)+process.mproducer8, cms.ConditionalTask(process.None, process.mproducer10), cms.ConditionalTask(process.messource, process.mproducer10, process.mproducer2, process.mproducer8, process.myTask5), cms.Task(), process.myTask100, process.myTask5)\n')
+
+            process.path23 = process.path22.copyAndExclude([process.messource, process.mproducer10])
+            self.assertEqual(process.path23.dumpPython(PrintOptions()), 'cms.Path(process.mproducer8+process.mproducer8+(process.mproducer8+process.mproducer9)+process.mproducer8, cms.ConditionalTask(process.None), cms.ConditionalTask(process.mproducer2, process.mproducer8, process.myTask5), cms.Task(), process.myTask100, process.myTask5)\n')
+
+            process = Process("Test")
+
+            process.b = EDProducer("b")
+            process.b2 = EDProducer("b2")
+            process.b3 = EDProducer("b3")
+            process.p = Path(process.b, ConditionalTask(process.b3, process.b2))
+            p = TestMakePSet()
+            process.fillProcessDesc(p)
+            self.assertEqual(p.values["@all_modules"], (True, ['b', 'b2', 'b3']))
+            self.assertEqual(p.values["@paths"], (True, ['p']))
+            self.assertEqual(p.values["p"], (True, ['b','#','b2','b3','@']))
+            
 
         def testPath(self):
             p = Process("test")
@@ -2873,21 +3167,32 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertRaises(TypeError,Path,p.es)
 
             t = Path()
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path()\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path()\n')
 
             t = Path(p.a)
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(process.a)\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a)\n')
 
             t = Path(Task())
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(cms.Task())\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(cms.Task())\n')
 
             t = Path(p.a, Task())
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(process.a, cms.Task())\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.Task())\n')
 
             p.prod = EDProducer("prodName")
             p.t1 = Task(p.prod)
             t = Path(p.a, p.t1, Task(), p.t1)
-            self.assertTrue(t.dumpPython(PrintOptions()) == 'cms.Path(process.a, cms.Task(), process.t1)\n')
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.Task(), process.t1)\n')
+
+            t = Path(ConditionalTask())
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(cms.ConditionalTask())\n')
+
+            t = Path(p.a, ConditionalTask())
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.ConditionalTask())\n')
+
+            p.prod = EDProducer("prodName")
+            p.t1 = ConditionalTask(p.prod)
+            t = Path(p.a, p.t1, Task(), p.t1)
+            self.assertEqual(t.dumpPython(PrintOptions()), 'cms.Path(process.a, cms.Task(), process.t1)\n')
 
         def testFinalPath(self):
             p = Process("test")
@@ -2919,7 +3224,11 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             p.prod = EDProducer("prodName")
             p.t1 = Task(p.prod)
             self.assertRaises(TypeError, FinalPath, p.a, p.t1, Task(), p.t1)
-            
+
+            p.prod = EDProducer("prodName")
+            p.t1 = ConditionalTask(p.prod)
+            self.assertRaises(TypeError, FinalPath, p.a, p.t1, ConditionalTask(), p.t1)
+
             p.t = FinalPath(p.a)
             p.a = OutputModule("ReplacedOutputModule")
             self.assertEqual(p.t.dumpPython(PrintOptions()), 'cms.FinalPath(process.a)\n')
@@ -2959,7 +3268,8 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
 
             seq1 = Sequence(e)
             task1 = Task(g)
-            path = Path(a * c * seq1, task1)
+            ctask1 = ConditionalTask(h)
+            path = Path(a * c * seq1, task1, ctask1)
 
             self.assertTrue(path.contains(a))
             self.assertFalse(path.contains(b))
@@ -2968,6 +3278,7 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertTrue(path.contains(e))
             self.assertFalse(path.contains(f))
             self.assertTrue(path.contains(g))
+            self.assertTrue(path.contains(h))
 
             endpath = EndPath(h * i)
             self.assertFalse(endpath.contains(b))
@@ -2997,6 +3308,14 @@ process.s2 = cms.Sequence(process.a+(process.a+process.a))""")
             self.assertTrue(sch.contains(k))
             self.assertTrue(sch.contains(l))
             self.assertTrue(sch.contains(m))
+
+            ctask2 = ConditionalTask(l, task1)
+            ctask = ConditionalTask(j, k, ctask2)
+            self.assertFalse(ctask.contains(b))
+            self.assertTrue(ctask.contains(j))
+            self.assertTrue(ctask.contains(k))
+            self.assertTrue(ctask.contains(l))
+            self.assertTrue(ctask.contains(g))
 
         def testSchedule(self):
             p = Process("test")
@@ -3302,6 +3621,10 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
                                          test1 = EDProducer("Bar",
                                                             aa = int32(11),
                                                             bb = PSet(cc = int32(12))))
+            self.assertEqual(proc.sp.label_(), "sp")
+            self.assertEqual(proc.sp.test1.label_(), "sp@test1")
+            self.assertEqual(proc.sp.test2.label_(), "sp@test2")
+
             proc.a = EDProducer("A")
             proc.s = Sequence(proc.a + proc.sp)
             proc.t = Task(proc.a, proc.sp)
@@ -3378,6 +3701,26 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertEqual((True,"EDAlias"), p.values["sp@test2"][1].values["@module_edm_type"])
             self.assertEqual((True,"Bar"), p.values["sp@test2"][1].values["a"][1][0].values["type"])
 
+            # ConditionalTask
+            proc = Process("test")
+            proc.spct = SwitchProducerTest(test2 = EDProducer("Foo",
+                                                              a = int32(1),
+                                                              b = PSet(c = int32(2))),
+                                           test1 = EDProducer("Bar",
+                                                              aa = int32(11),
+                                                              bb = PSet(cc = int32(12))),
+                                           test3 = EDAlias(a = VPSet(PSet(type = string("Bar")))))
+            proc.spp = proc.spct.clone()
+            proc.a = EDProducer("A")
+            proc.ct = ConditionalTask(proc.spct)
+            proc.p = Path(proc.a, proc.ct)
+            proc.pp = Path(proc.a + proc.spp)
+            p = TestMakePSet()
+            proc.fillProcessDesc(p)
+            self.assertEqual(["a", "spct", "spct@test1", "spct@test2", "spp", "spp@test1", "spp@test2"], p.values["@all_modules"][1])
+            self.assertEqual(["a", "#", "spct", "spct@test1", "spct@test2", "@"], p.values["p"][1])
+            self.assertEqual(["a", "spp", "#", "spp@test1", "spp@test2", "@"], p.values["pp"][1])
+
         def testPrune(self):
             p = Process("test")
             p.a = EDAnalyzer("MyAnalyzer")
@@ -3387,11 +3730,15 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             p.e = EDProducer("MyProducer")
             p.f = EDProducer("YourProducer")
             p.g = EDProducer("TheirProducer")
+            p.h = EDProducer("OnesProducer")
             p.s = Sequence(p.d)
             p.t1 = Task(p.e)
             p.t2 = Task(p.f)
             p.t3 = Task(p.g, p.t1)
-            p.path1 = Path(p.a, p.t3)
+            p.ct1 = ConditionalTask(p.h)
+            p.ct2 = ConditionalTask(p.f)
+            p.ct3 = ConditionalTask(p.ct1)
+            p.path1 = Path(p.a, p.t3, p.ct3)
             p.path2 = Path(p.b)
             self.assertTrue(p.schedule is None)
             pths = p.paths
@@ -3410,6 +3757,7 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertTrue(hasattr(p, 'e'))
             self.assertTrue(not hasattr(p, 'f'))
             self.assertTrue(hasattr(p, 'g'))
+            self.assertTrue(hasattr(p, 'h'))
             self.assertTrue(not hasattr(p, 's'))
             self.assertTrue(hasattr(p, 't1'))
             self.assertTrue(not hasattr(p, 't2'))
@@ -3431,14 +3779,21 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             p.g = EDProducer("YourProducer")
             p.h = EDProducer("TheirProducer")
             p.i = EDProducer("OurProducer")
+            p.j = EDProducer("OurProducer")
+            p.k = EDProducer("OurProducer")
+            p.l = EDProducer("OurProducer")
             p.t1 = Task(p.f)
             p.t2 = Task(p.g)
             p.t3 = Task(p.h)
             p.t4 = Task(p.i)
-            p.s = Sequence(p.d, p.t1)
-            p.s2 = Sequence(p.b, p.t2)
+            p.ct1 = Task(p.f)
+            p.ct2 = Task(p.j)
+            p.ct3 = Task(p.k)
+            p.ct4 = Task(p.l)
+            p.s = Sequence(p.d, p.t1, p.ct1)
+            p.s2 = Sequence(p.b, p.t2, p.ct2)
             p.s3 = Sequence(p.e)
-            p.path1 = Path(p.a, p.t3)
+            p.path1 = Path(p.a, p.t3, p.ct3)
             p.path2 = Path(p.b)
             p.path3 = Path(p.b+p.s2)
             p.path4 = Path(p.b+p.s3)
@@ -3458,10 +3813,17 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             self.assertTrue(hasattr(p, 'g'))
             self.assertTrue(hasattr(p, 'h'))
             self.assertTrue(hasattr(p, 'i'))
+            self.assertTrue(hasattr(p, 'j'))
+            self.assertTrue(hasattr(p, 'k'))
+            self.assertTrue(not hasattr(p, 'l'))
             self.assertTrue(not hasattr(p, 't1'))
             self.assertTrue(hasattr(p, 't2'))
             self.assertTrue(hasattr(p, 't3'))
             self.assertTrue(hasattr(p, 't4'))
+            self.assertTrue(not hasattr(p, 'ct1'))
+            self.assertTrue(hasattr(p, 'ct2'))
+            self.assertTrue(hasattr(p, 'ct3'))
+            self.assertTrue(not hasattr(p, 'ct4'))
             self.assertTrue(not hasattr(p, 's'))
             self.assertTrue(hasattr(p, 's2'))
             self.assertTrue(not hasattr(p, 's3'))
@@ -3495,6 +3857,17 @@ process.addSubProcess(cms.SubProcess(process = childProcess, SelectEvents = cms.
             p.a = EDProducer("MyProducer")
             p.b = EDProducer("YourProducer")
             p.s = Task(TaskPlaceholder("a"),p.b)
+            p.pth = Path(p.s)
+            p.prune()
+            self.assertTrue(hasattr(p, 'a'))
+            self.assertTrue(hasattr(p, 'b'))
+            self.assertTrue(hasattr(p, 's'))
+            self.assertTrue(hasattr(p, 'pth'))
+            #test ConditionalTaskPlaceholder
+            p = Process("test")
+            p.a = EDProducer("MyProducer")
+            p.b = EDProducer("YourProducer")
+            p.s = ConditionalTask(ConditionalTaskPlaceholder("a"),p.b)
             p.pth = Path(p.s)
             p.prune()
             self.assertTrue(hasattr(p, 'a'))
@@ -3579,6 +3952,65 @@ process.t5 = cms.Task(process.a, process.g, process.t4)
 process.path1 = cms.Path(process.b, process.t2, process.t3)
 process.endpath1 = cms.EndPath(process.b, process.t5)
 process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[process.t7, process.t8])""")
+        def testConditionalTaskPlaceholder(self):
+            p = Process("test")
+            p.a = EDProducer("ma")
+            p.b = EDAnalyzer("mb")
+            p.t1 = ConditionalTask(ConditionalTaskPlaceholder("c"))
+            p.t2 = ConditionalTask(p.a, ConditionalTaskPlaceholder("d"), p.t1)
+            p.t3 = ConditionalTask(ConditionalTaskPlaceholder("e"))
+            p.path1 = Path(p.b, p.t2, p.t3)
+            p.t5 = ConditionalTask(p.a, ConditionalTaskPlaceholder("g"), ConditionalTaskPlaceholder("t4"))
+            p.t4 = ConditionalTask(ConditionalTaskPlaceholder("f"))
+            p.path2 = Path(p.b, p.t5)
+            p.schedule = Schedule(p.path1, p.path2)
+            p.c = EDProducer("mc")
+            p.d = EDProducer("md")
+            p.e = EDProducer("me")
+            p.f = EDProducer("mf")
+            p.g = EDProducer("mg")
+            p.h = EDProducer("mh")
+            p.i = EDProducer("mi")
+            p.j = EDProducer("mj")
+            self.assertEqual(_lineDiff(p.dumpPython(),Process('test').dumpPython()),
+"""process.a = cms.EDProducer("ma")
+process.c = cms.EDProducer("mc")
+process.d = cms.EDProducer("md")
+process.e = cms.EDProducer("me")
+process.f = cms.EDProducer("mf")
+process.g = cms.EDProducer("mg")
+process.h = cms.EDProducer("mh")
+process.i = cms.EDProducer("mi")
+process.j = cms.EDProducer("mj")
+process.b = cms.EDAnalyzer("mb")
+process.t1 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("c"))
+process.t2 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("d"), process.a, process.t1)
+process.t3 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("e"))
+process.t5 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("g"), cms.ConditionalTaskPlaceholder("t4"), process.a)
+process.t4 = cms.ConditionalTask(cms.ConditionalTaskPlaceholder("f"))
+process.path1 = cms.Path(process.b, process.t2, process.t3)
+process.path2 = cms.Path(process.b, process.t5)
+process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
+            p.resolve()
+            self.assertEqual(_lineDiff(p.dumpPython(),Process('test').dumpPython()),
+"""process.a = cms.EDProducer("ma")
+process.c = cms.EDProducer("mc")
+process.d = cms.EDProducer("md")
+process.e = cms.EDProducer("me")
+process.f = cms.EDProducer("mf")
+process.g = cms.EDProducer("mg")
+process.h = cms.EDProducer("mh")
+process.i = cms.EDProducer("mi")
+process.j = cms.EDProducer("mj")
+process.b = cms.EDAnalyzer("mb")
+process.t1 = cms.ConditionalTask(process.c)
+process.t2 = cms.ConditionalTask(process.a, process.d, process.t1)
+process.t3 = cms.ConditionalTask(process.e)
+process.t4 = cms.ConditionalTask(process.f)
+process.t5 = cms.ConditionalTask(process.a, process.g, process.t4)
+process.path1 = cms.Path(process.b, process.t2, process.t3)
+process.path2 = cms.Path(process.b, process.t5)
+process.schedule = cms.Schedule(*[ process.path1, process.path2 ])""")
 
         def testDelete(self):
             p = Process("test")
@@ -3590,31 +4022,46 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             p.f = EDAnalyzer("OurAnalyzer")
             p.g = EDProducer("OurProducer")
             p.h = EDProducer("YourProducer")
-            p.t1 = Task(p.g, p.h)
-            t2 = Task(p.g, p.h)
+            p.i = SwitchProducerTest(
+                test1 = EDProducer("OneProducer"),
+                test2 = EDProducer("TwoProducer")
+            )
+            p.t1 = Task(p.g, p.h, p.i)
+            t2 = Task(p.g, p.h, p.i)
             t3 = Task(p.g, p.h)
             p.t4 = Task(p.h)
+            p.ct1 = ConditionalTask(p.g, p.h, p.i)
+            ct2 = ConditionalTask(p.g, p.h)
+            ct3 = ConditionalTask(p.g, p.h)
+            p.ct4 = ConditionalTask(p.h)
             p.s = Sequence(p.d+p.e)
-            p.path1 = Path(p.a+p.f+p.s,t2)
+            p.path1 = Path(p.a+p.f+p.s,t2,ct2)
             p.path2 = Path(p.a)
+            p.path3 = Path(ct3, p.ct4)
             p.endpath2 = EndPath(p.b)
             p.endpath1 = EndPath(p.b+p.f)
-            p.schedule = Schedule(p.path2, p.endpath2, tasks=[t3, p.t4])
+            p.schedule = Schedule(p.path2, p.path3, p.endpath2, tasks=[t3, p.t4])
             self.assertTrue(hasattr(p, 'f'))
             self.assertTrue(hasattr(p, 'g'))
+            self.assertTrue(hasattr(p, 'i'))
             del p.e
             del p.f
             del p.g
+            del p.i
             self.assertFalse(hasattr(p, 'f'))
             self.assertFalse(hasattr(p, 'g'))
             self.assertEqual(p.t1.dumpPython(), 'cms.Task(process.h)\n')
+            self.assertEqual(p.ct1.dumpPython(), 'cms.ConditionalTask(process.h)\n')
             self.assertEqual(p.s.dumpPython(), 'cms.Sequence(process.d)\n')
-            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+process.s, cms.Task(process.h))\n')
+            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+process.s, cms.ConditionalTask(process.h), cms.Task(process.h))\n')
             self.assertEqual(p.endpath1.dumpPython(), 'cms.EndPath(process.b)\n')
+            self.assertEqual(p.path3.dumpPython(), 'cms.Path(cms.ConditionalTask(process.h), process.ct4)\n')
             del p.s
-            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+(process.d), cms.Task(process.h))\n')
-            self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.path2, process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
+            self.assertEqual(p.path1.dumpPython(), 'cms.Path(process.a+(process.d), cms.ConditionalTask(process.h), cms.Task(process.h))\n')
+            self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.path2, process.path3, process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
             del p.path2
+            self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.path3, process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
+            del p.path3
             self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(*[ process.endpath2 ], tasks=[cms.Task(process.h), process.t4])\n')
             del p.endpath2
             self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(tasks=[cms.Task(process.h), process.t4])\n')
@@ -3622,6 +4069,11 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.schedule_().dumpPython(), 'cms.Schedule(tasks=[cms.Task(process.h)])\n')
         def testModifier(self):
             m1 = Modifier()
+            Process._firstProcess = True
+            p = Process("test")
+            self.assertRaises(RuntimeError, lambda: Process("test2", m1))
+            m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1))
             def _mod_fred(obj):
@@ -3634,6 +4086,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertTrue(p.isUsingModifier(m1))
             #check that Modifier not attached to a process doesn't run
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test")
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1))
             m1.toModify(p.a,_mod_fred)
@@ -3644,6 +4097,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.isUsingModifier(m1),False)
             #make sure clones get the changes
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             m1.toModify(p.a, fred = int32(2))
@@ -3654,6 +4108,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.b.wilma.value(),3)
             #test removal of parameter
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1), fintstones = PSet(fred = int32(1)))
             m1.toModify(p.a, fred = None, fintstones = dict(fred = None))
@@ -3662,6 +4117,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.wilma.value(),1)
             #test adding a parameter
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1))
             m1.toModify(p.a, wilma = int32(2))
@@ -3669,6 +4125,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.wilma.value(),2)
             #test setting of value in PSet
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", flintstones = PSet(fred = int32(1), wilma = int32(1)))
             m1.toModify(p.a, flintstones = dict(fred = int32(2)))
@@ -3676,12 +4133,14 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.flintstones.wilma.value(),1)
             #test proper exception from nonexisting parameter name
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", flintstones = PSet(fred = PSet(wilma = int32(1))))
             self.assertRaises(KeyError, lambda: m1.toModify(p.a, flintstones = dict(imnothere = dict(wilma=2))))
             self.assertRaises(KeyError, lambda: m1.toModify(p.a, foo = 1))
             #test setting a value in a VPSet
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", flintstones = VPSet(PSet(fred = int32(1)), PSet(wilma = int32(1))))
             m1.toModify(p.a, flintstones = {1:dict(wilma = int32(2))})
@@ -3689,6 +4148,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.flintstones[1].wilma.value(),2)
             #test setting a value in a list of values
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = vuint32(1,2,3))
             m1.toModify(p.a, fred = {1:7})
@@ -3697,6 +4157,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.fred[2],3)
             #test IndexError setting a value in a list to an item key not in the list
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = vuint32(1,2,3))
             raised = False
@@ -3705,6 +4166,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(raised, True)
             #test TypeError setting a value in a list using a key that is not an int
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", flintstones = VPSet(PSet(fred = int32(1)), PSet(wilma = int32(1))))
             raised = False
@@ -3724,6 +4186,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             p.extend(testMod)
             self.assertTrue(hasattr(p,"a"))
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             testProcMod = ProcModifierMod(m1,_rem_a)
             p.extend(testMod)
@@ -3732,6 +4195,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             #test ModifierChain
             m1 = Modifier()
             mc = ModifierChain(m1)
+            Process._firstProcess = True
             p = Process("test",mc)
             self.assertTrue(p.isUsingModifier(m1))
             self.assertTrue(p.isUsingModifier(mc))
@@ -3759,6 +4223,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             #check combining
             m1 = Modifier()
             m2 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             (m1 & m2).toModify(p.a, fred = int32(2))
@@ -3766,6 +4231,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.fred, 1)
             m1 = Modifier()
             m2 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1,m2)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             (m1 & m2).toModify(p.a, fred = int32(2))
@@ -3773,6 +4239,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             m1 = Modifier()
             m2 = Modifier()
             m3 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1,m2,m3)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             (m1 & m2 & m3).toModify(p.a, fred = int32(2))
@@ -3784,6 +4251,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             #check inverse
             m1 = Modifier()
             m2 = Modifier()
+            Process._firstProcess = True
             p = Process("test", m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             (~m1).toModify(p.a, fred=2)
@@ -3796,6 +4264,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             m1 = Modifier()
             m2 = Modifier()
             m3 = Modifier()
+            Process._firstProcess = True
             p = Process("test", m1)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             (m1 | m2).toModify(p.a, fred=2)
@@ -3817,6 +4286,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             m2 = Modifier()
             m3 = Modifier()
             m4 = Modifier()
+            Process._firstProcess = True
             p = Process("test", m1, m2)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             (m1 & ~m2).toModify(p.a, fred=2)
@@ -3833,10 +4303,12 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             self.assertEqual(p.a.fred, 5)
             #check toReplaceWith
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test",m1)
             p.a =EDAnalyzer("MyAnalyzer", fred = int32(1))
             m1.toReplaceWith(p.a, EDAnalyzer("YourAnalyzer", wilma = int32(3)))
             self.assertRaises(TypeError, lambda: m1.toReplaceWith(p.a, EDProducer("YourProducer")))
+            #Task
             p.b =EDAnalyzer("BAn")
             p.c =EDProducer("c")
             p.d =EDProducer("d")
@@ -3851,8 +4323,26 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             p.e =EDProducer("e")
             m1.toReplaceWith(p.td, Task(p.e))
             self.assertTrue(p.td._collection == OrderedSet([p.e]))
+            #ConditionalTask
+            p.b =EDAnalyzer("BAn")
+            p.c =EDProducer("c")
+            p.d =EDProducer("d")
+            del p.tc
+            del p.td
+            p.tc = ConditionalTask(p.c)
+            p.td = ConditionalTask(p.d)
+            p.s = Sequence(p.a, p.tc)
+            m1.toReplaceWith(p.s, Sequence(p.a+p.b, p.td))
+            self.assertEqual(p.a.wilma.value(),3)
+            self.assertEqual(p.a.type_(),"YourAnalyzer")
+            self.assertEqual(hasattr(p,"fred"),False)
+            self.assertTrue(p.s.dumpPython() == "cms.Sequence(process.a+process.b, process.td)\n")
+            p.e =EDProducer("e")
+            m1.toReplaceWith(p.td, ConditionalTask(p.e))
+            self.assertTrue(p.td._collection == OrderedSet([p.e]))
             #check toReplaceWith doesn't activate not chosen
             m1 = Modifier()
+            Process._firstProcess = True
             p = Process("test")
             p.a =EDAnalyzer("MyAnalyzer", fred = int32(1))
             m1.toReplaceWith(p.a, EDAnalyzer("YourAnalyzer", wilma = int32(3)))
@@ -3862,6 +4352,7 @@ process.schedule = cms.Schedule(*[ process.path1, process.endpath1 ], tasks=[pro
             m2 = Modifier()
             m3 = Modifier()
             m4 = Modifier()
+            Process._firstProcess = True
             p = Process("test", m1, m2)
             p.a = EDAnalyzer("MyAnalyzer", fred = int32(1), wilma = int32(1))
             self.assertRaises(TypeError, lambda: (m1 & m2).toReplaceWith(p.a, EDProducer("YourProducer")))

--- a/python/FWCore/ParameterSet/Modules.py
+++ b/python/FWCore/ParameterSet/Modules.py
@@ -252,6 +252,14 @@ class SwitchProducer(EDProducer):
         self.__setParameters(kargs)
         self._isModified = False
 
+    def setLabel(self, label):
+        super(SwitchProducer,self).setLabel(label)
+        # SwitchProducer owns the contained modules, and therefore
+        # need to set / unset the label for them explicitly here
+        for case in self.parameterNames_():
+            producer = self.__dict__[case]
+            producer.setLabel(self.caseLabel_(label, case) if label is not None else None)
+
     @staticmethod
     def getCpu():
         """Returns a function that returns the priority for a CPU "computing device". Intended to be used by deriving classes."""
@@ -288,6 +296,8 @@ class SwitchProducer(EDProducer):
             message += self.dumpPython() + '\n'
             raise ValueError(message)
         self.__dict__[name]=value
+        if self.hasLabel_():
+            value.setLabel(self.caseLabel_(self.label_(), name))
         self._Parameterizable__parameterNames.append(name)
         self._isModified = True
 
@@ -318,6 +328,8 @@ class SwitchProducer(EDProducer):
                 raise TypeError(name+" can only be set to a cms.EDProducer or cms.EDAlias")
             # We should always receive an cms.EDProducer
             self.__dict__[name] = value
+            if self.hasLabel_():
+                value.setLabel(self.caseLabel_(self.label_(), name))
             self._isModified = True
 
     def clone(self, **params):
@@ -368,6 +380,14 @@ class SwitchProducer(EDProducer):
         return myname
     def caseLabel_(self, name, case):
         return name+"@"+case
+    def modulesForConditionalTask_(self):
+        # Need the contained modules (not EDAliases) for ConditionalTask
+        ret = []
+        for case in self.parameterNames_():
+            caseobj = self.__dict__[case]
+            if not isinstance(caseobj, EDAlias):
+                ret.append(caseobj)
+        return ret
     def appendToProcessDescLists_(self, modules, aliases, myname):
         # This way we can insert the chosen EDProducer to @all_modules
         # so that we get easily a worker for it
@@ -386,8 +406,8 @@ class SwitchProducer(EDProducer):
         newpset.addString(True, "@module_label", self.moduleLabel_(myname))
         newpset.addString(True, "@module_type", "SwitchProducer")
         newpset.addString(True, "@module_edm_type", "EDProducer")
-        newpset.addVString(True, "@all_cases", [myname+"@"+p for p in self.parameterNames_()])
-        newpset.addString(False, "@chosen_case", myname+"@"+self._chooseCase(accelerators))
+        newpset.addVString(True, "@all_cases", [self.caseLabel_(myname, p) for p in self.parameterNames_()])
+        newpset.addString(False, "@chosen_case", self.caseLabel_(myname, self._chooseCase(accelerators)))
         parameterSet.addPSet(True, self.nameInProcessDesc_(myname), newpset)
 
     def _placeImpl(self,name,proc):
@@ -550,6 +570,24 @@ if __name__ == "__main__":
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESProducer("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = ESPrefer("Foo")))
             self.assertRaises(TypeError, lambda: SwitchProducerTest(test1 = SwitchProducerTest(test1 = EDProducer("Foo"))))
+
+            # Label
+            sp.setLabel("sp")
+            self.assertEqual(sp.label_(), "sp")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            self.assertEqual(sp.test2.label_(), "sp@test2")
+            sp.test3 = EDProducer("Xyzzy")
+            self.assertEqual(sp.test3.label_(), "sp@test3")
+            sp.test1 = EDProducer("Fred")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            del sp.test1
+            sp.test1 = EDProducer("Wilma")
+            self.assertEqual(sp.test1.label_(), "sp@test1")
+            sp.setLabel(None)
+            sp.setLabel("other")
+            self.assertEqual(sp.label_(), "other")
+            self.assertEqual(sp.test1.label_(), "other@test1")
+            self.assertEqual(sp.test2.label_(), "other@test2")
 
             # Case decision
             accelerators = ["test1", "test2", "test3"]

--- a/python/FWCore/ParameterSet/SequenceTypes.py
+++ b/python/FWCore/ParameterSet/SequenceTypes.py
@@ -243,8 +243,14 @@ def findDirectDependencies(element, collection,sortByType=True):
                 dependencies += item.directDependencies(sortByType)
                 continue
             t = 'tasks'
+        # cms.ConditionalTask
+        elif isinstance(item, ConditionalTask):
+            if not item.hasLabel_():
+                dependencies += item.directDependencies(sortByType)
+                continue
+            t = 'conditionaltasks'
         # SequencePlaceholder and TaskPlaceholder do not add an explicit dependency
-        elif isinstance(item, (SequencePlaceholder, TaskPlaceholder)):
+        elif isinstance(item, (SequencePlaceholder, TaskPlaceholder, ConditionalTaskPlaceholder)):
             continue
         # unsupported elements
         else:
@@ -262,7 +268,7 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
     def __init__(self,*arg, **argv):
         self.__dict__["_isFrozen"] = False
         self._seq = None
-        if (len(arg) > 1 and not isinstance(arg[1], Task)) or (len(arg) > 0 and not isinstance(arg[0],_Sequenceable) and not isinstance(arg[0],Task)):
+        if (len(arg) > 1 and not isinstance(arg[1], _TaskBase)) or (len(arg) > 0 and not isinstance(arg[0],_Sequenceable) and not isinstance(arg[0],_TaskBase)):
             typename = format_typename(self)
             msg = format_outerframe(2)
             msg += "The %s constructor takes zero or one sequenceable argument followed by zero or more arguments of type Task. But the following types are given:\n" %typename
@@ -287,7 +293,7 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
             self.associate(*tasks)
     def associate(self,*tasks):
         for task in tasks:
-            if not isinstance(task, Task):
+            if not isinstance(task, _TaskBase):
                 raise TypeError("associate only works with objects of type Task")
             self._tasks.add(task)
     def isFrozen(self):
@@ -444,8 +450,10 @@ class _ModuleSequenceType(_ConfigureComponent, _Labelable):
         # where objects that contain other objects are involved. See the comments
         # for the _MutatingSequenceVisitor.
 
-        if isinstance(original,Task) != isinstance(replacement,Task):
+        if (isinstance(original,Task) != isinstance(replacement,Task)):
                raise TypeError("replace only works if both arguments are Tasks or neither")
+        if (isinstance(original,ConditionalTask) != isinstance(replacement,ConditionalTask)):
+               raise TypeError("replace only works if both arguments are ConditionalTasks or neither")
         v = _CopyAndReplaceSequenceVisitor(original,replacement)
         self.visit(v)
         if v.didReplace():
@@ -857,6 +865,18 @@ class TaskVisitor(object):
     def leave(self,visitee):
         pass
 
+# Fills a list of all ConditionalTasks visited
+# Can visit a ConditionalTask, Sequence, Path, or EndPath
+class ConditionalTaskVisitor(object):
+    def __init__(self,d):
+        self.deps = d
+    def enter(self,visitee):
+        if isinstance(visitee,ConditionalTask):
+            self.deps.append(visitee)
+        pass
+    def leave(self,visitee):
+        pass
+
 # Fills a list of all modules visited.
 # Can visit a Sequence, Path, EndPath, or Task
 # For purposes of this visitor, a module is considered
@@ -895,6 +915,29 @@ class ModuleNodeOnTaskVisitor(object):
     def leave(self,visitee):
         if self._levelInTasks > 0:
             if isinstance(visitee, Task):
+                self._levelInTasks -= 1
+
+class ModuleNodeOnConditionalTaskVisitor(object):
+    def __init__(self,l):
+        self.l = l
+        self._levelInTasks = 0
+    def enter(self,visitee):
+        if isinstance(visitee, ConditionalTask):
+            self._levelInTasks += 1
+        # This block gets the modules contained by SwitchProducer. It
+        # needs to be before the "levelInTasks == 0" check because the
+        # contained modules need to be treated like in ConditionalTask
+        # also when the SwitchProducer itself is in the Path.
+        if hasattr(visitee, "modulesForConditionalTask_"):
+            self.l.extend(visitee.modulesForConditionalTask_())
+        if self._levelInTasks == 0:
+            return
+        if visitee.isLeaf():
+            self.l.append(visitee)
+        pass
+    def leave(self,visitee):
+        if self._levelInTasks > 0:
+            if isinstance(visitee, ConditionalTask):
                 self._levelInTasks -= 1
 
 # Should not be used on Tasks.
@@ -961,7 +1004,7 @@ class NodeNameVisitor(object):
                 if visitee._inProcess:
                     self.l.add(visitee.type_())
                 else:
-                    raise RuntimeError("Service not attached to process")
+                    raise RuntimeError("Service not attached to process: {}".format(visitee.dumpPython()))
     def leave(self,visitee):
         pass
 
@@ -973,14 +1016,25 @@ class ExpandVisitor(object):
         self._type = type
         self.l = []
         self.taskLeaves = []
+        self.taskLeavesInConditionalTasks = []
+        self.presentTaskLeaves = self.taskLeaves
         self._levelInTasks = 0
+        self.conditionaltaskLeaves = []
+        self._levelInConditionalTasks = 0
+
     def enter(self,visitee):
         if isinstance(visitee, Task):
             self._levelInTasks += 1
             return
+        if isinstance(visitee, ConditionalTask):
+            self.presentTaskLeaves = self.taskLeavesInConditionalTasks
+            self._levelInConditionalTasks += 1
+            return
         if visitee.isLeaf():
             if self._levelInTasks > 0:
-                self.taskLeaves.append(visitee)
+                self.presentTaskLeaves.append(visitee)
+            elif self._levelInConditionalTasks > 0:
+                self.conditionaltaskLeaves.append(visitee)
             else:
                 self.l.append(visitee)
     def leave(self, visitee):
@@ -988,18 +1042,31 @@ class ExpandVisitor(object):
             if isinstance(visitee, Task):
                 self._levelInTasks -= 1
             return
+        if self._levelInConditionalTasks > 0:
+            if isinstance(visitee, ConditionalTask):
+                self._levelInConditionalTasks -= 1
+                if 0 == self._levelInConditionalTasks:
+                  self.presentTaskLeaves = self.taskLeaves
+            return
         if isinstance(visitee,_UnarySequenceOperator):
             self.l[-1] = visitee
     def result(self):
-        tsk = Task(*self.taskLeaves)
+        tsks = []
+        if self.taskLeaves:
+          tsks.append(Task(*self.taskLeaves))
+        if self.conditionaltaskLeaves:
+          ct = ConditionalTask(*self.conditionaltaskLeaves)
+          if self.taskLeavesInConditionalTasks:
+            ct.append(*self.taskLeavesInConditionalTasks)
+          tsks.append(ct)
         if len(self.l) > 0:
             # why doesn't (sum(self.l) work?
             seq = self.l[0]
             for el in self.l[1:]:
                 seq += el
-            return self._type(seq, tsk)
+            return self._type(seq, *tsks)
         else:
-            return self._type(tsk)
+            return self._type(*tsks)
     def resultString(self):
         sep = ''
         returnValue = ''
@@ -1031,7 +1098,7 @@ class DecoratedNodeNameVisitor(object):
         self._levelInTasks = 0
 
     def enter(self,visitee):
-        if isinstance(visitee, Task):
+        if isinstance(visitee, _TaskBase):
             self._levelInTasks += 1
         if self._levelInTasks > 0:
             return
@@ -1055,7 +1122,7 @@ class DecoratedNodeNameVisitor(object):
     def leave(self,visitee):
         # Ignore if this visitee is inside a Task
         if self._levelInTasks > 0:
-            if isinstance(visitee, Task):
+            if isinstance(visitee, _TaskBase):
                 self._levelInTasks -= 1
             return
         if isinstance(visitee,_BooleanLogicExpression):
@@ -1335,19 +1402,19 @@ class _MutatingSequenceVisitor(object):
                 node.__init__(contents[0][0])
                 self.__stack[-2][-1] = [node, True, None]
 
-            elif isinstance(visitee, Task):
+            elif isinstance(visitee, _TaskBase):
                 nonNull = []
                 for c in contents:
                     if c[0] is not None:
                         nonNull.append(c[0])
-                self.__stack[-2][-1] = [Task(*nonNull), True, None]
+                self.__stack[-2][-1] = [visitee._makeInstance(*nonNull), True, None]
             elif isinstance(visitee, Sequence):
                 seq = _SequenceCollection()
                 tasks = list()
                 for c in contents:
                     if c[0] is None:
                         continue
-                    if isinstance(c[0], Task):
+                    if isinstance(c[0], _TaskBase):
                         tasks.append(c[0])
                     else:
                         seq = seq + c[0]
@@ -1364,7 +1431,7 @@ class _MutatingSequenceVisitor(object):
 
     def result(self, visitedContainer):
 
-        if isinstance(visitedContainer, Task):
+        if isinstance(visitedContainer, _TaskBase):
             result = list()
             for n in (x[0] for x in self.__stack[0]):
                 if n is not None:
@@ -1376,7 +1443,7 @@ class _MutatingSequenceVisitor(object):
         for c in self.__stack[0]:
             if c[0] is None:
                 continue
-            if isinstance(c[0], Task):
+            if isinstance(c[0], _TaskBase):
                 tasks.append(c[0])
             else:
                 seq = seq + c[0]
@@ -1435,38 +1502,23 @@ class _CopyAndReplaceSequenceVisitor(_MutatingSequenceVisitor):
     def didReplace(self):
         return self._didApply()
 
-class Task(_ConfigureComponent, _Labelable) :
-    """Holds EDProducers, EDFilters, ESProducers, ESSources, Services, and Tasks.
-    A Task can be associated with Sequences, Paths, EndPaths and the Schedule.
-    An EDProducer or EDFilter will be enabled to run unscheduled if it is on
-    a task associated with the Schedule or any scheduled Path or EndPath (directly
-    or indirectly through Sequences) and not be on any scheduled Path or EndPath.
-    ESSources, ESProducers, and Services will be enabled to run if they are on
-    a Task associated with the Schedule or a scheduled Path or EndPath.  In other
-    cases, they will be enabled to run if and only if they are not on a Task attached
-    to the process.
-    """
-
+class _TaskBase(_ConfigureComponent, _Labelable) :
     def __init__(self, *items):
         self._collection = OrderedSet()
         self.add(*items)
 
     def __setattr__(self,name,value):
         if not name.startswith("_"):
-            raise AttributeError("You cannot set parameters for Task objects.")
+            raise AttributeError("You cannot set parameters for {} objects.".format(self._taskType()))
         else:
             self.__dict__[name] = value
 
     def add(self, *items):
         for item in items:
-            if not isinstance(item, _ConfigureComponent) or not item._isTaskComponent():
-                if not isinstance(item, TaskPlaceholder):
-                    raise RuntimeError("Adding an entry of type '" + type(item).__name__ + "'to a Task.\n"
-                                       "It is illegal to add this type to a Task.")
+            if not self._allowedInTask(item):
+                raise RuntimeError("Adding an entry of type '{0}' to a {1}.\n"
+                                   "It is illegal to add this type to a {1}.".format(type(item).__name__, self._taskType()))
             self._collection.add(item)
-
-    def _place(self, name, proc):
-        proc._placeTask(name,self)
 
     def fillContents(self, taskContents, options=PrintOptions()):
         # only dump the label, if possible
@@ -1474,7 +1526,7 @@ class Task(_ConfigureComponent, _Labelable) :
             taskContents.add(_Labelable.dumpSequencePython(self, options))
         else:
             for i in self._collection:
-                if isinstance(i, Task):
+                if isinstance(i, _TaskBase):
                     i.fillContents(taskContents, options)
                 else:
                     taskContents.add(i.dumpSequencePython(options))
@@ -1487,7 +1539,7 @@ class Task(_ConfigureComponent, _Labelable) :
         """Returns a string which is the python representation of the object"""
         taskContents = set()
         for i in self._collection:
-            if isinstance(i, Task):
+            if isinstance(i, _TaskBase):
                 i.fillContents(taskContents, options)
             else:
                 taskContents.add(i.dumpSequencePython(options))
@@ -1499,14 +1551,14 @@ class Task(_ConfigureComponent, _Labelable) :
             iFirst = False
             s += item
         if len(taskContents) > 255:
-            return "cms.Task(*[" + s + "])"
-        return "cms.Task(" + s + ")"
+            s = "*[" + s + "]"
+        return "cms.{}({})".format(self._taskType(),s)
 
     def directDependencies(self,sortByType=True):
         return findDirectDependencies(self, self._collection,sortByType=sortByType)
 
     def _isTaskComponent(self):
-        return True
+        return False
 
     def isLeaf(self):
         return False
@@ -1519,7 +1571,7 @@ class Task(_ConfigureComponent, _Labelable) :
             visitor.leave(i)
 
     def _errorstr(self):
-        return "Task(...)"
+        return "{}(...)".format(self.taskType_())
 
     def __iter__(self):
         for key in self._collection:
@@ -1551,7 +1603,7 @@ class Task(_ConfigureComponent, _Labelable) :
         self.visit(visitor)
         return visitor.result()
     def copy(self):
-        return Task(*self._collection)
+        return self._makeInstance(*self._collection)
     def copyAndExclude(self,listOfModulesToExclude):
         """Returns a copy of the sequence which excludes those module in 'listOfModulesToExclude'"""
         # You can exclude instances of these types EDProducer, EDFilter, ESSource, ESProducer,
@@ -1564,7 +1616,7 @@ class Task(_ConfigureComponent, _Labelable) :
                 raise TypeError("copyAndExclude can only exclude objects that can be placed on a Task")
         v = _CopyAndExcludeSequenceVisitor(listOfModulesToExclude)
         self.visit(v)
-        return Task(*v.result(self))
+        return self._makeInstance(*v.result(self))
     def copyAndAdd(self, *modulesToAdd):
         """Returns a copy of the Task adding modules/tasks"""
         t = self.copy()
@@ -1578,7 +1630,7 @@ class Task(_ConfigureComponent, _Labelable) :
         l = []
         v = ModuleNodeVisitor(l)
         self.visit(v)
-        return Task(*l)
+        return self._makeInstance(*l)
     def replace(self, original, replacement):
         """Finds all instances of 'original' and substitutes 'replacement' for them.
            Returns 'True' if a replacement occurs."""
@@ -1589,10 +1641,10 @@ class Task(_ConfigureComponent, _Labelable) :
         # where objects that contain other objects are involved. See the comments
         # for the _MutatingSequenceVisitor.
 
-        if not original._isTaskComponent() or (not replacement is None and not replacement._isTaskComponent()):
-           raise TypeError("The Task replace function only works with objects that can be placed on a Task\n" + \
-                           "           replace was called with original type = " + str(type(original)) + "\n" + \
-                           "           and replacement type = " + str(type(replacement)) + "\n")
+        if not self._allowedInTask(original) or (not replacement is None and not self._allowedInTask(replacement)):
+           raise TypeError("The {0} replace function only works with objects that can be placed on a {0}\n".format(self._taskType()) + \
+                           "           replace was called with original type = {}\n".format(str(type(original))) + \
+                           "           and replacement type = {}\n".format(str(type(replacement))))
         else:
             v = _CopyAndReplaceSequenceVisitor(original,replacement)
             self.visit(v)
@@ -1614,7 +1666,7 @@ class Task(_ConfigureComponent, _Labelable) :
         # Works very similar to copyAndExclude, there are 2 differences. This changes
         # the object itself instead of making a copy and second it only removes
         # the first instance of the argument instead of all of them.
-        if not something._isTaskComponent():
+        if not self._allowedInTask(something):
            raise TypeError("remove only works with objects that can be placed on a Task")
         v = _CopyAndRemoveFirstSequenceVisitor(something)
         self.visit(v)
@@ -1626,18 +1678,18 @@ class Task(_ConfigureComponent, _Labelable) :
     def resolve(self, processDict,keepIfCannotResolve=False):
         temp = OrderedSet()
         for i in self._collection:
-            if isinstance(i, Task) or isinstance(i, TaskPlaceholder):
+            if self._mustResolve(i):
                 temp.add(i.resolve(processDict,keepIfCannotResolve))
             else:
                 temp.add(i)
         self._collection = temp
         return self
-
-class TaskPlaceholder(object):
+        
+class _TaskBasePlaceholder(object):
     def __init__(self, name):
         self._name = name
     def _isTaskComponent(self):
-        return True
+        return False
     def isLeaf(self):
         return False
     def visit(self,visitor):
@@ -1645,31 +1697,116 @@ class TaskPlaceholder(object):
     def __str__(self):
         return self._name
     def insertInto(self, parameterSet, myname):
-        raise RuntimeError("The TaskPlaceholder "+self._name
-                           +" was never overridden")
+        raise RuntimeError("The {} {} was never overridden".format(self._typeName(), self._name))
     def resolve(self, processDict,keepIfCannotResolve=False):
         if not self._name in processDict:
             if keepIfCannotResolve:
                 return self
-            raise RuntimeError("The TaskPlaceholder "+self._name+ " cannot be resolved.\n Known keys are:"+str(processDict.keys()))
+            raise RuntimeError("The {} {} cannot be resolved.\n Known keys are: {}".format(self._typeName(), self._name,str(processDict.keys())))
         o = processDict[self._name]
-        if not o._isTaskComponent():
-            raise RuntimeError("The TaskPlaceholder "+self._name+ " refers to an object type which is not allowed to be on a task: "+str(type(o)))
-        if isinstance(o, Task):
+        if not self._allowedInTask(o):
+            raise RuntimeError("The {} {} refers to an object type which is not allowed to be on a task: {}".format(self._typeName(), self._name, str(type(o))))
+        if isinstance(o, self._taskClass()):
             return o.resolve(processDict)
         return o
     def copy(self):
-        returnValue =TaskPlaceholder.__new__(type(self))
-        returnValue.__init__(self._name)
-        return returnValue
+        return self._makeInstance(self._name)
     def dumpSequencePython(self, options=PrintOptions()):
-        return 'cms.TaskPlaceholder("%s")'%self._name
+        return 'cms.{}("{}")'.format(self._typeName(), self._name)
     def dumpPython(self, options=PrintOptions()):
-        result = 'cms.TaskPlaceholder(\"'
+        result = 'cms.{}(\"'.format(self._typeName())
         if options.isCfg:
            result += 'process.'
         result += self._name+'\")\n'
         return result
+
+class Task(_TaskBase) :
+    """Holds EDProducers, EDFilters, ESProducers, ESSources, Services, and Tasks.
+    A Task can be associated with Sequences, Paths, EndPaths, ConditionalTasks and the Schedule.
+    An EDProducer or EDFilter will be enabled to run unscheduled if it is on
+    a task associated with the Schedule or any scheduled Path or EndPath (directly
+    or indirectly through Sequences) and not be on any scheduled Path or EndPath.
+    ESSources, ESProducers, and Services will be enabled to run if they are on
+    a Task associated with the Schedule or a scheduled Path or EndPath.  In other
+    cases, they will be enabled to run if and only if they are not on a Task attached
+    to the process.
+    """
+    @staticmethod
+    def _taskType():
+      return "Task"
+    def _place(self, name, proc):
+        proc._placeTask(name,self)
+    def _isTaskComponent(self):
+        return True
+    @staticmethod
+    def _makeInstance(*items):
+      return Task(*items)
+    @staticmethod
+    def _allowedInTask(item ):
+      return (isinstance(item, _ConfigureComponent) and item._isTaskComponent()) or isinstance(item, TaskPlaceholder)
+    @staticmethod
+    def _mustResolve(item):
+        return isinstance(item, Task) or isinstance(item, TaskPlaceholder)
+      
+class TaskPlaceholder(_TaskBasePlaceholder):
+    def _isTaskComponent(self):
+        return True
+    @staticmethod
+    def _typeName():
+      return "TaskPlaceholder"
+    @staticmethod
+    def _makeInstance(name):
+      return TaskPlaceholder(name)
+    @staticmethod
+    def _allowedInTask(obj):
+      return Task._allowedInTask(obj)
+    @staticmethod
+    def _taskClass():
+      return Task
+
+
+class ConditionalTask(_TaskBase) :
+    """Holds EDProducers, EDFilters, ESProducers, ESSources, Services, Tasks and ConditionalTasks.
+    A ConditionalTask can be associated with Sequences, Paths, and EndPaths.
+    An EDProducer or EDFilter will be added to a Path or EndPath based on which other
+    modules on the Path consumes its data products. If that ConditionalTask assigned module
+    is placed after an EDFilter, the module will only run if the EDFilter passes. If no module
+    on the Path needs the module's data products, the module will be treated as if it were on a Task.
+    """
+    @staticmethod
+    def _taskType():
+      return "ConditionalTask"
+    def _place(self, name, proc):
+        proc._placeConditionalTask(name,self)
+    def _isTaskComponent(self):
+        return False
+    @staticmethod
+    def _makeInstance(*items):
+      return ConditionalTask(*items)
+    @staticmethod
+    def _allowedInTask(item):
+      return isinstance(item, ConditionalTask) or isinstance(item, ConditionalTaskPlaceholder) or Task._allowedInTask(item)
+    @staticmethod
+    def _mustResolve(item):
+        return Task._mustResolve(item) or isinstance(item, ConditionalTask) or isinstance(item, ConditionalTaskPlaceholder)
+
+
+class ConditionalTaskPlaceholder(_TaskBasePlaceholder):
+    def _isTaskComponent(self):
+        return False
+    @staticmethod
+    def _typeName():
+      return "ConditionalTaskPlaceholder"
+    @staticmethod
+    def _makeInstance(name):
+      return ConditionalTaskPlaceholder(name)
+    @staticmethod
+    def _allowedInTask(obj):
+      return Task._allowedInTask(obj) or ConditionalTask._allowedInTask(obj)
+    @staticmethod
+    def _taskClass():
+      return ConditionalTask
+
 
 if __name__=="__main__":
     import unittest
@@ -1769,6 +1906,10 @@ if __name__=="__main__":
             p6.visit(namesVisitor)
             self.assertEqual(l,['!&','a','b','@'])
 
+        def testTaskConstructor(self):
+            a = DummyModule("a")
+            self.assertRaises(RuntimeError, lambda : Task(ConditionalTask(a)) )
+
         def testDumpPython(self):
             a = DummyModule("a")
             b = DummyModule('b')
@@ -1817,6 +1958,33 @@ if __name__=="__main__":
             s = Sequence(e, t4)
             p12 = Path(a+b+s+c,t1)
             self.assertEqual(p12.dumpPython(),"cms.Path(process.a+process.b+cms.Sequence(process.e, cms.Task(process.d, process.f))+process.c, cms.Task(process.a))\n")
+            ct1 = ConditionalTask(a)
+            ct2 = ConditionalTask(c, b)
+            ct3 = ConditionalTask()
+            p13 = Path((a+b)*c, ct1)
+            self.assertEqual(p13.dumpPython(),"cms.Path(process.a+process.b+process.c, cms.ConditionalTask(process.a))\n")
+            p14 = Path((a+b)*c, ct2, ct1)
+            self.assertEqual(p14.dumpPython(),"cms.Path(process.a+process.b+process.c, cms.ConditionalTask(process.a), cms.ConditionalTask(process.b, process.c))\n")
+            p15 = Path(ct1, ct2, ct3)
+            self.assertEqual(p15.dumpPython(),"cms.Path(cms.ConditionalTask(), cms.ConditionalTask(process.a), cms.ConditionalTask(process.b, process.c))\n")
+            ct4 = ConditionalTask(d, Task(f))
+            s = Sequence(e, ct4)
+            p16 = Path(a+b+s+c,ct1)
+            self.assertEqual(p16.dumpPython(),"cms.Path(process.a+process.b+cms.Sequence(process.e, cms.ConditionalTask(process.d, process.f))+process.c, cms.ConditionalTask(process.a))\n")
+
+            n = 260
+            mods = []
+            labels = []
+            for i in range(0, n):
+                l = "a{}".format(i)
+                labels.append("process."+l)
+                mods.append(DummyModule(l))
+            labels.sort()
+            task = Task(*mods)
+            self.assertEqual(task.dumpPython(), "cms.Task(*[" + ", ".join(labels) + "])\n")
+            conditionalTask = ConditionalTask(*mods)
+            self.assertEqual(conditionalTask.dumpPython(), "cms.ConditionalTask(*[" + ", ".join(labels) + "])\n")
+
             l = list()
             namesVisitor = DecoratedNodeNameVisitor(l)
             p.visit(namesVisitor)
@@ -1843,6 +2011,9 @@ if __name__=="__main__":
             p12.visit(namesVisitor)
             self.assertEqual(l, ['a', 'b', 'e', 'c'])
             l[:] = []
+            p16.visit(namesVisitor)
+            self.assertEqual(l, ['a', 'b', 'e', 'c'])
+            l[:] = []
             moduleVisitor = ModuleNodeVisitor(l)
             p8.visit(moduleVisitor)
             names = [m.label_() for m in l]
@@ -1851,6 +2022,8 @@ if __name__=="__main__":
             self.assertEqual(tph.dumpPython(), 'cms.TaskPlaceholder("process.a")\n')
             sph = SequencePlaceholder('a')
             self.assertEqual(sph.dumpPython(), 'cms.SequencePlaceholder("process.a")\n')
+            ctph = ConditionalTaskPlaceholder('a')
+            self.assertEqual(ctph.dumpPython(), 'cms.ConditionalTaskPlaceholder("process.a")\n')
 
         def testDumpConfig(self):
             a = DummyModule("a")
@@ -1913,6 +2086,19 @@ if __name__=="__main__":
             e=DummyModule("e")
             f=DummyModule("f")
             g=DummyModule("g")
+            ct1 = ConditionalTask(d)
+            ct2 = ConditionalTask(e, ct1)
+            ct3 = ConditionalTask(f, g, ct2)
+            s=Sequence(plusAB, ct3, ct2)
+            multSC = s*c
+            p=Path(multSC, ct1, ct2)
+            l = []
+            v = ModuleNodeVisitor(l)
+            p.visit(v)
+            expected = [a,b,f,g,e,d,e,d,c,d,e,d]
+            self.assertEqual(expected,l)
+
+
             t1 = Task(d)
             t2 = Task(e, t1)
             t3 = Task(f, g, t2)
@@ -1924,6 +2110,7 @@ if __name__=="__main__":
             v = ModuleNodeVisitor(l)
             p.visit(v)
             expected = [a,b,f,g,e,d,e,d,c,d,e,d]
+            self.assertEqual(expected,l)
 
             l[:] = []
             v = ModuleNodeOnTaskVisitor(l)
@@ -2050,6 +2237,7 @@ if __name__=="__main__":
             m8 = DummyModule("m8")
             m9 = DummyModule("m9")
 
+            #Task
             t6 = Task(m6)
             t7 = Task(m7)
             t89 = Task(m8, m9)
@@ -2105,7 +2293,65 @@ if __name__=="__main__":
             t3 = Task(m5)
             t2.replace(m2,t3)
             self.assertTrue(t2.dumpPython() == "cms.Task(process.m1, process.m3, process.m5)\n")
-            
+
+            #ConditionalTask
+            ct6 = ConditionalTask(m6)
+            ct7 = ConditionalTask(m7)
+            ct89 = ConditionalTask(m8, m9)
+
+            cs1 = Sequence(m1+m2, ct6)
+            cs2 = Sequence(m3+m4, ct7)
+            cs3 = Sequence(cs1+cs2, ct89)
+            cs3.replace(m3,m5)
+            l[:] = []
+            cs3.visit(namesVisitor)
+            self.assertEqual(l,['m1','m2','m5','m4'])
+
+            cs3.replace(m8,m1)
+            self.assertEqual(cs3.dumpPython(), "cms.Sequence(cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m6))+process.m5+process.m4, cms.ConditionalTask(process.m1, process.m9), cms.ConditionalTask(process.m7))\n")
+
+            cs3.replace(m1,m7)
+            self.assertEqual(cs3.dumpPython(), "cms.Sequence(process.m7+process.m2+process.m5+process.m4, cms.ConditionalTask(process.m6), cms.ConditionalTask(process.m7), cms.ConditionalTask(process.m7, process.m9))\n")
+            result = cs3.replace(ct7, ct89)
+            self.assertEqual(cs3.dumpPython(), "cms.Sequence(process.m7+process.m2+process.m5+process.m4, cms.ConditionalTask(process.m6), cms.ConditionalTask(process.m7, process.m9), cms.ConditionalTask(process.m8, process.m9))\n")
+            self.assertTrue(result)
+            result = cs3.replace(ct7, ct89)
+            self.assertFalse(result)
+
+            ct1 = ConditionalTask()
+            ct1.replace(m1,m2)
+            self.assertEqual(ct1.dumpPython(), "cms.ConditionalTask()\n")
+
+            ct1 = ConditionalTask(m1)
+            ct1.replace(m1,m2)
+            self.assertEqual(ct1.dumpPython(), "cms.ConditionalTask(process.m2)\n")
+
+            ct1 = ConditionalTask(m1,m2, m2)
+            ct1.replace(m2,m3)
+            self.assertEqual(ct1.dumpPython(), "cms.ConditionalTask(process.m1, process.m3)\n")
+
+            ct1 = ConditionalTask(m1,m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct2.replace(m1,m4)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m2, process.m3, process.m4)\n")
+
+            ct1 = ConditionalTask(m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct2.replace(m1,m4)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m2, process.m3, process.m4)\n")
+
+            ct1 = ConditionalTask(m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct2.replace(ct1,m4)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m1, process.m3, process.m4)\n")
+
+            ct1 = ConditionalTask(m2)
+            ct2 = ConditionalTask(m1,m3,ct1)
+            ct3 = ConditionalTask(m5)
+            ct2.replace(m2,ct3)
+            self.assertEqual(ct2.dumpPython(), "cms.ConditionalTask(process.m1, process.m3, process.m5)\n")
+
+            #FinalPath
             fp = FinalPath()
             fp.replace(m1,m2)
             self.assertEqual(fp.dumpPython(), "cms.FinalPath()\n")
@@ -2131,7 +2377,7 @@ if __name__=="__main__":
             s3._replaceIfHeldDirectly(~m1, m2)
             self.assertEqual(s3.dumpPython()[:-1],
                              "cms.Sequence(process.m2+(process.m1+process.m2))")
-
+            #Task
             m6 = DummyModule("m6")
             m7 = DummyModule("m7")
             m8 = DummyModule("m8")
@@ -2153,6 +2399,23 @@ if __name__=="__main__":
             s1._replaceIfHeldDirectly(t6,t7)
             self.assertEqual(s1.dumpPython()[:-1],"cms.Sequence(cms.Task(process.m7))")
 
+            #ConditionalTask
+            ct6 = ConditionalTask(m6)
+            ct7 = ConditionalTask(m7)
+            ct89 = ConditionalTask(m8, m9)
+
+            s1 = Sequence(m1+m2, ct6)
+            s2 = Sequence(m3+m4, ct7)
+            s3 = Sequence(s1+s2, ct89)
+            s3._replaceIfHeldDirectly(m3,m5)
+            self.assertEqual(s3.dumpPython()[:-1], "cms.Sequence(cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m6))+cms.Sequence(process.m3+process.m4, cms.ConditionalTask(process.m7)), cms.ConditionalTask(process.m8, process.m9))")
+            s2._replaceIfHeldDirectly(m3,m5)
+            self.assertEqual(s2.dumpPython()[:-1],"cms.Sequence(process.m5+process.m4, cms.ConditionalTask(process.m7))")
+            self.assertEqual(s3.dumpPython()[:-1], "cms.Sequence(cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m6))+cms.Sequence(process.m5+process.m4, cms.ConditionalTask(process.m7)), cms.ConditionalTask(process.m8, process.m9))")
+
+            s1 = Sequence(ct6)
+            s1._replaceIfHeldDirectly(ct6,ct7)
+            self.assertEqual(s1.dumpPython()[:-1],"cms.Sequence(cms.ConditionalTask(process.m7))")
         def testIndex(self):
             m1 = DummyModule("a")
             m2 = DummyModule("b")
@@ -2199,6 +2462,7 @@ if __name__=="__main__":
             p2.visit(namesVisitor)
             self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
 
+            #Task
             m6 = DummyModule("m6")
             m7 = DummyModule("m7")
             m8 = DummyModule("m8")
@@ -2208,7 +2472,7 @@ if __name__=="__main__":
             l[:] = []
             p2.visit(namesVisitor)
             self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
-            self.assertTrue(p2.dumpPython() == "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.Task(process.m6))\n")
+            self.assertEqual(p2.dumpPython(), "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.Task(process.m6))\n")
 
             s2 = Sequence(m1*m2, Task(m9))
             s3 = Sequence(~m1*s2)
@@ -2236,6 +2500,44 @@ if __name__=="__main__":
             t4 = Task()
             t5 = t4.expandAndClone()
             self.assertTrue(t5.dumpPython() == "cms.Task()\n")
+            #ConditionalTask
+            s1 = Sequence(m1*~m2*m1*m2*ignore(m2))
+            s2 = Sequence(m1*m2)
+            s3 = Sequence(~m1*s2)
+            p = Path(s1+s3, ConditionalTask(m6))
+            p2 = p.expandAndClone()
+            l[:] = []
+            p2.visit(namesVisitor)
+            self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
+            self.assertEqual(p2.dumpPython(), "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.ConditionalTask(process.m6))\n")
+
+            s2 = Sequence(m1*m2, ConditionalTask(m9))
+            s3 = Sequence(~m1*s2)
+            ct8 = ConditionalTask(m8)
+            ct8.setLabel("ct8")
+            p = Path(s1+s3, ConditionalTask(m6, ConditionalTask(m7, ct8)))
+            p2 = p.expandAndClone()
+            l[:] = []
+            p2.visit(namesVisitor)
+            self.assertEqual(l, ['m1', '!m2', 'm1', 'm2', '-m2', '!m1', 'm1', 'm2'])
+            self.assertEqual(p2.dumpPython(), "cms.Path(process.m1+~process.m2+process.m1+process.m2+cms.ignore(process.m2)+~process.m1+process.m1+process.m2, cms.ConditionalTask(process.m6, process.m7, process.m8, process.m9))\n")
+
+            t1 = ConditionalTask(m1,m2,m3)
+            s1 = Sequence(t1)
+            s2 = s1.expandAndClone()
+            l[:] = []
+            s2.visit(namesVisitor)
+            self.assertEqual(l, [])
+            self.assertEqual(s2.dumpPython(), "cms.Sequence(cms.ConditionalTask(process.m1, process.m2, process.m3))\n")
+
+            t1 = ConditionalTask(m1,m2)
+            t2 = ConditionalTask(m1,m3,t1)
+            t3 = t2.expandAndClone()
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m1, process.m2, process.m3)\n")
+            t4 = ConditionalTask()
+            t5 = t4.expandAndClone()
+            self.assertTrue(t5.dumpPython() == "cms.ConditionalTask()\n")
+
         def testAdd(self):
             m1 = DummyModule("m1")
             m2 = DummyModule("m2")
@@ -2320,6 +2622,7 @@ if __name__=="__main__":
             s4.remove(m1)
             l[:]=[]; s4.visit(namesVisitor); self.assertEqual(l,[])
             self.assertEqual(s4.dumpPython(), "cms.Sequence()\n")
+            #Task
             s1 = Sequence(m1+m2, Task(m3), Task(m4))
             s1.remove(m4)
             self.assertEqual(s1.dumpPython(), "cms.Sequence(process.m1+process.m2, cms.Task(process.m3))\n")
@@ -2339,6 +2642,27 @@ if __name__=="__main__":
             self.assertTrue(t3.dumpPython() == "cms.Task(process.m2)\n")
             t3.remove(m2)
             self.assertTrue(t3.dumpPython() == "cms.Task()\n")
+            #ConditionalTask
+            s1 = Sequence(m1+m2, ConditionalTask(m3), ConditionalTask(m4))
+            s1.remove(m4)
+            self.assertEqual(s1.dumpPython(), "cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m3))\n")
+            s1 = Sequence(m1+m2+Sequence(ConditionalTask(m3,m4), ConditionalTask(m3), ConditionalTask(m4)))
+            s1.remove(m4)
+            self.assertEqual(s1.dumpPython(), "cms.Sequence(process.m1+process.m2, cms.ConditionalTask(process.m3), cms.ConditionalTask(process.m4))\n")
+            t1 = ConditionalTask(m1)
+            t1.setLabel("t1")
+            t2 = ConditionalTask(m2,t1)
+            t2.setLabel("t2")
+            t3 = ConditionalTask(t1,t2,m1)
+            t3.remove(m1)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m1, process.t2)\n")
+            t3.remove(m1)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m1, process.m2)\n")
+            t3.remove(m1)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.m2)\n")
+            t3.remove(m2)
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask()\n")
+            #FinalPath
             fp = FinalPath(m1+m2)
             fp.remove(m1)
             self.assertEqual(fp.dumpPython(), "cms.FinalPath(process.m2)\n")
@@ -2445,6 +2769,7 @@ if __name__=="__main__":
             self.assertEqual(s.copyAndExclude([d]).dumpPython(),"cms.Sequence(process.a+process.b+process.c)\n")
             self.assertEqual(s.copyAndExclude([a,b,c,d]).dumpPython(),"cms.Sequence()\n")
 
+            #Task
             e = DummyModule("e")
             f = DummyModule("f")
             g = DummyModule("g")
@@ -2481,6 +2806,40 @@ if __name__=="__main__":
             self.assertTrue(t3.dumpPython() == "cms.Task(process.f, process.g, process.t11)\n")
             t4 = t2.copyAndExclude([e,f,g,h,a])
             self.assertTrue(t4.dumpPython() == "cms.Task()\n")
+            #ConditionalTask
+            t1 = ConditionalTask(h)
+            s = Sequence(a+b+c+~d, ConditionalTask(e,f,ConditionalTask(g,t1)))
+            self.assertEqual(s.copyAndExclude([a,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            self.assertEqual(s.copyAndExclude([a,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            self.assertEqual(s.copyAndExclude([a,e,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.f, process.g))\n")
+            self.assertEqual(s.copyAndExclude([a,e,f,g,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d)\n")
+            self.assertEqual(s.copyAndExclude([a,b,c,d]).dumpPython(),"cms.Sequence(cms.ConditionalTask(process.e, process.f, process.g, process.h))\n")
+            self.assertEqual(s.copyAndExclude([t1]).dumpPython(),"cms.Sequence(process.a+process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            taskList = []
+            taskVisitor = ConditionalTaskVisitor(taskList)
+            s.visit(taskVisitor)
+            self.assertEqual(len(taskList),3)
+            s2 = s.copyAndExclude([g,h])
+            taskList[:] = []
+            s2.visit(taskVisitor)
+            self.assertEqual(len(taskList),1)
+            t2 = ConditionalTask(t1)
+            taskList[:] = []
+            t2.visit(taskVisitor)
+            self.assertEqual(taskList[0],t1)
+            s3 = Sequence(s)
+            self.assertEqual(s3.copyAndExclude([a,h]).dumpPython(),"cms.Sequence(process.b+process.c+~process.d, cms.ConditionalTask(process.e, process.f, process.g))\n")
+            s4 = Sequence(s)
+            self.assertEqual(s4.copyAndExclude([a,b,c,d,e,f,g,h]).dumpPython(),"cms.Sequence()\n")
+            t1 = ConditionalTask(e,f)
+            t11 = ConditionalTask(a)
+            t11.setLabel("t11")
+            t2 = ConditionalTask(g,t1,h,t11)
+            t3 = t2.copyAndExclude([e,h])
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.f, process.g, process.t11)\n")
+            t4 = t2.copyAndExclude([e,f,g,h,a])
+            self.assertEqual(t4.dumpPython(), "cms.ConditionalTask()\n")
+
         def testSequenceTypeChecks(self):
             m1 = DummyModule("m1")
             m2 = DummyModule("m2")
@@ -2506,6 +2865,7 @@ if __name__=="__main__":
             p1 += e
             self.assertEqual(p1.dumpPython(),"cms.Path(process.a+process.b+process.c+process.e)\n")
             self.assertEqual(p2.dumpPython(),"cms.Path(process.a+process.b+process.c)\n")
+            #Task
             t1 = Task(a, b)
             t2 = t1.copy()
             self.assertTrue(t1.dumpPython() == t2.dumpPython())
@@ -2514,12 +2874,23 @@ if __name__=="__main__":
             self.assertTrue(id(t1Contents[0]) == id(t2Contents[0]))
             self.assertTrue(id(t1Contents[1]) == id(t2Contents[1]))
             self.assertTrue(id(t1._collection) != id(t2._collection))
+            #ConditionalTask
+            t1 = ConditionalTask(a, b)
+            t2 = t1.copy()
+            self.assertTrue(t1.dumpPython() == t2.dumpPython())
+            t1Contents = list(t1._collection)
+            t2Contents = list(t2._collection)
+            self.assertTrue(id(t1Contents[0]) == id(t2Contents[0]))
+            self.assertTrue(id(t1Contents[1]) == id(t2Contents[1]))
+            self.assertTrue(id(t1._collection) != id(t2._collection))
+
         def testCopyAndAdd(self):
             a = DummyModule("a")
             b = DummyModule("b")
             c = DummyModule("c")
             d = DummyModule("d")
             e = DummyModule("e")
+            #Task
             t1 = Task(a, b, c)
             self.assertEqual(t1.dumpPython(), "cms.Task(process.a, process.b, process.c)\n")
             t2 = t1.copyAndAdd(d, e)
@@ -2535,6 +2906,23 @@ if __name__=="__main__":
             self.assertEqual(t5.dumpPython(), "cms.Task(process.a, process.c, process.d, process.e)\n")
             t6 = t4.copyAndAdd(Task(b))
             self.assertEqual(t6.dumpPython(), "cms.Task(process.a, process.b, process.c, process.d)\n")
+            #ConditionalTask
+            t1 = ConditionalTask(a, b, c)
+            self.assertEqual(t1.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c)\n")
+            t2 = t1.copyAndAdd(d, e)
+            self.assertEqual(t1.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c)\n")
+            self.assertEqual(t2.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c, process.d, process.e)\n")
+            t3 = t2.copyAndExclude([b])
+            self.assertEqual(t1.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c)\n")
+            self.assertEqual(t2.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c, process.d, process.e)\n")
+            self.assertEqual(t3.dumpPython(), "cms.ConditionalTask(process.a, process.c, process.d, process.e)\n")
+            t4 = t1.copyAndExclude([b]).copyAndAdd(d)
+            self.assertEqual(t4.dumpPython(), "cms.ConditionalTask(process.a, process.c, process.d)\n")
+            t5 = t2.copyAndExclude([b]).copyAndAdd(d)
+            self.assertEqual(t5.dumpPython(), "cms.ConditionalTask(process.a, process.c, process.d, process.e)\n")
+            t6 = t4.copyAndAdd(Task(b))
+            self.assertEqual(t6.dumpPython(), "cms.ConditionalTask(process.a, process.b, process.c, process.d)\n")
+
         def testInsertInto(self):
             from FWCore.ParameterSet.Types import vstring
             class TestPSet(object):

--- a/python/FWCore/ParameterSet/SequenceVisitors.py
+++ b/python/FWCore/ParameterSet/SequenceVisitors.py
@@ -120,19 +120,24 @@ class NodeVisitor(object):
 
 class CompositeVisitor(object):
     """ Combines 3 different visitor classes in 1 so we only have to visit all the paths and endpaths once"""
-    def __init__(self, validator, node, decorated):
+    def __init__(self, validator, node, decorated, optional=None):
         self._validator = validator
         self._node = node
         self._decorated = decorated
+        self._optional = optional
     def enter(self, visitee):
         self._validator.enter(visitee)
         self._node.enter(visitee)
         self._decorated.enter(visitee)
+        if self._optional:
+          self._optional.enter(visitee)
     def leave(self, visitee):
         self._validator.leave(visitee)
         # The node visitor leave function does nothing
         #self._node.leave(visitee)
         self._decorated.leave(visitee)
+        if self._optional:
+          self._optional.leave(visitee)
 
 class ModuleNamesFromGlobalsVisitor(object):
     """Fill a list with the names of Event module types in a sequence. The names are determined

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-03-00
+confdb.version=V03-04-00
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/converter/python/PythonTaskWriter.java
+++ b/src/confdb/converter/python/PythonTaskWriter.java
@@ -6,10 +6,20 @@ import confdb.converter.ConverterEngine;
 import confdb.converter.ITaskWriter;
 import confdb.data.Reference;
 import confdb.data.Task;
+import confdb.data.ReleaseVersionInfo;
 
 public class PythonTaskWriter implements ITaskWriter {
 	public String toString(Task task, ConverterEngine converterEngine, String object) {
-		String str = object + task.name() + " = cms.Task( ";
+		
+		ReleaseVersionInfo relInfo = new ReleaseVersionInfo(task.config().releaseTag());
+		String taskType = null;
+		if(relInfo.geq(12,4,0,4)){
+			taskType = new String("cms.ConditionalTask");
+		}else{
+			taskType = new String("cms.Task");
+		}
+
+		String str = object + task.name() + " = "+taskType+"( ";
 		if (task.entryCount() > 0) {
 			String sep = " , ";
 			Iterator<Reference> list = task.entryIterator();

--- a/src/confdb/converter/python/PythonTaskWriter.java
+++ b/src/confdb/converter/python/PythonTaskWriter.java
@@ -13,7 +13,7 @@ public class PythonTaskWriter implements ITaskWriter {
 		
 		ReleaseVersionInfo relInfo = new ReleaseVersionInfo(task.config().releaseTag());
 		String taskType = null;
-		if(relInfo.geq(12,4,0,4)){
+		if(relInfo.geq(12,4,0) && !(relInfo.equals(12,5,0,1))){
 			taskType = new String("cms.ConditionalTask");
 		}else{
 			taskType = new String("cms.Task");

--- a/src/confdb/parser/JPythonParser.java
+++ b/src/confdb/parser/JPythonParser.java
@@ -653,8 +653,14 @@ public class JPythonParser
     // Parse Sequences:
     private void parseTasksFromPython(PyObject pyprocess){
         PyDictionary tasks = (PyDictionary) pyprocess.__getattr__("_Process__tasks");
-        if (validPyObject(tasks))
+        if (validPyObject(tasks)){
             parseTasksMap(tasks);
+        }
+        PyDictionary condtasks = (PyDictionary) pyprocess.__getattr__("_Process__conditionaltasks");
+        if (validPyObject(condtasks)){
+            parseTasksMap(condtasks);
+        }
+
     }
     
     // Parse SwitchProducers:
@@ -1240,8 +1246,11 @@ public class JPythonParser
 	if(sequenceContent.__findattr__("_tasks")!=null){	 
 	    collection.extend(sequenceContent.__getattr__("_tasks"));
 	}
+    if(sequenceContent.__findattr__("_conditionaltasks")!=null){	 
+	    collection.extend(sequenceContent.__getattr__("_conditionaltasks"));
+	}
 
-        if (pythonObjects.switchProducer.is(getType(sequenceContent))){
+    if (pythonObjects.switchProducer.is(getType(sequenceContent))){
 	   System.out.println("ERROR should not be a SP here ");
 	}	
 
@@ -1267,6 +1276,19 @@ public class JPythonParser
             {
                 // Parse sub-items of label task on demand:
                 PyDictionary tasks = (PyDictionary) process.__getattr__("_Process__tasks");
+                PyObject task = tasks.__getitem__(new PyString(label));
+                confdb.data.Task subTask = parseTask(task);
+
+                // If task reference does not exist in this container, add it!
+                Reference reference = parentContainer.entry(label);
+                if (reference == null)
+                    reference = configuration.insertTaskReference(parentContainer, parentContainer.entryCount(), subTask);
+            }
+            else if (pythonObjects.condtask.is(type))
+            // ConditionalTask
+            {
+                // Parse sub-items of label task on demand:
+                PyDictionary tasks = (PyDictionary) process.__getattr__("_Process__conditionaltasks");
                 PyObject task = tasks.__getitem__(new PyString(label));
                 confdb.data.Task subTask = parseTask(task);
 
@@ -1408,7 +1430,7 @@ public class JPythonParser
     }
     
     private void parseTasksMap(PyDictionary pydict) {
-        alert(msg.inf, " Tasks (" + pydict.size() + ")");
+        alert(msg.inf, " ConditionalTasks (" + pydict.size() + ")");
         PyList keys = (PyList) pydict.invoke("keys");
 
         for (Object key : keys) {
@@ -1428,7 +1450,7 @@ public class JPythonParser
         String label = getLabel(object);
         confdb.data.Task insertedTas = null;
 
-        if (confdbTypes.task.is(type)) {
+        if (confdbTypes.task.is(type) || confdbTypes.condTask.is(type)) {
             insertedTas = configuration.task(label);
 
             // create a new Task if needed
@@ -1638,6 +1660,7 @@ public class JPythonParser
     public enum confdbTypes {
         sequence("Sequence"),
         task("Task"), //not strickly a confdb type, see if this causes issues
+        condTask("ConditionalTask"), //not strickly a confdb type, see if this causes issues
         switchProducer("SwitchProducerCUDA"),
         path("Path"),
         endPath("EndPath"),
@@ -1728,8 +1751,9 @@ public class JPythonParser
         seqIgnore("_SequenceIgnore"),
         seqOpAids("_SequenceOpAids"),
         task("Task"),
+        condtask("ConditionalTask"),
         switchProducer("SwitchProducerCUDA"),
-	EDAlias("EDAlias"),
+	    EDAlias("EDAlias"),
         EDProducer("EDProducer"),
         EDFilter("EDFilter"),
         EDAnalyzer("EDAnalyzer"),

--- a/src/confdb/parser/JPythonParser.java
+++ b/src/confdb/parser/JPythonParser.java
@@ -1246,9 +1246,6 @@ public class JPythonParser
 	if(sequenceContent.__findattr__("_tasks")!=null){	 
 	    collection.extend(sequenceContent.__getattr__("_tasks"));
 	}
-    if(sequenceContent.__findattr__("_conditionaltasks")!=null){	 
-	    collection.extend(sequenceContent.__getattr__("_conditionaltasks"));
-	}
 
     if (pythonObjects.switchProducer.is(getType(sequenceContent))){
 	   System.out.println("ERROR should not be a SP here ");


### PR DESCRIPTION
~~This PR makes Tasks Conditional in 12_4_0_pre4~~

~~It simply replaces Task with ConditionalTask when the release is greater than 12_4_0_pre4.~~

~~Although when writing this, I just realised we will need to fix the parser  to understand this as well.~~

_Updated after integration_ :

This PR makes Tasks Conditional in `12_4_0` and higher (with the exception of `12_5_0_pre1`).

It simply replaces `cms.Task` with `cms.ConditionalTask` based on the version of the `ConfDB` template of a given menu.

The `ConfDB` python parser has been updated accordingly; it now parses both `cms.Task`s and `cms.ConditionalTask`s into the single "Task" container used internally by `ConfDB`.