### PR TITLE
adding check for paths with multiple versions present

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-07-13 Sam Harper
+    * tag V03-04-02
+	* config check introduced which means two versions of the same path now prevents the menu from saving
+
 2022-06-23 Andrea Bocci
     * tag V03-04-01
 	* adapts config look up to use OMS tables, now enabling config look up by run number again

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-04-01
+confdb.version=V03-04-02
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/


### PR DESCRIPTION
This PR makes it an error checked at save time for a path to have multiple versions of it existing in a single menu 

Thus a menu can no longer have HLT_Path_v1 and HLT_Path_v2

This will not work when run due to the paths by construction sharing a prescaler