### PR TITLE
adding proxy/tunnel settings for ORCOFF database

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-08-02 Sam Harper
+    * tag V03-04-03
+	* adding tunnel setting for ORCOFF database
+	
 2022-07-13 Sam Harper
     * tag V03-04-02
 	* config check introduced which means two versions of the same path now prevents the menu from saving

--- a/src/conf/confdb.properties
+++ b/src/conf/confdb.properties
@@ -2,7 +2,7 @@
 #  ConfDB properties
 ###################################
 
-confdb.setupCount=16
+confdb.setupCount=18
 
 
 
@@ -63,75 +63,91 @@ confdb6.dbName=cms_orcon_adg.cern.ch
 confdb6.dbUser=cms_hlt_gdr_r
 confdb6.proxy=false
 
-confdb7.dbSetup=DAQ
+confdb7.dbSetup=ORCOFF (socks tunnel)
 confdb7.dbType=oracle
-confdb7.dbHost=cmsonr1-s.cms, cmsonr2-s.cms
+confdb7.dbHost=10.116.96.108, 10.116.96.109
 confdb7.dbPort=10121
-confdb7.dbName=cms_omds_lb.cern.ch
-confdb7.dbUser=cms_hlt_gdr_w
-confdb7.proxy=false
+confdb7.dbName=cms_orcon_adg.cern.ch
+confdb7.dbUser=cms_hlt_gdr_r
+confdb7.proxy=true
 
-confdb8.dbSetup=DAQ (direct tunnel)
+confdb8.dbSetup=ORCOFF (direct tunnel)
 confdb8.dbType=oracle
 confdb8.dbHost=localhost
 confdb8.dbPort=10121
-confdb8.dbName=cms_omds_tunnel.cern.ch
-confdb8.dbUser=cms_hlt_gdr_w
+confdb8.dbName=cms_orcon_adg.cern.ch
+confdb8.dbUser=cms_hlt_gdr_r
 confdb8.proxy=false
 
-confdb9.dbSetup=DAQ (direct tunnel, readonly)
+confdb9.dbSetup=DAQ
 confdb9.dbType=oracle
-confdb9.dbHost=localhost
+confdb9.dbHost=cmsonr1-s.cms, cmsonr2-s.cms
 confdb9.dbPort=10121
-confdb9.dbName=cms_omds_tunnel.cern.ch
-confdb9.dbUser=cms_hlt_gdr_r
+confdb9.dbName=cms_omds_lb.cern.ch
+confdb9.dbUser=cms_hlt_gdr_w
 confdb9.proxy=false
 
-confdb10.dbSetup=Offline Dev
+confdb10.dbSetup=DAQ (direct tunnel)
 confdb10.dbType=oracle
-confdb10.dbHost=cmsr1-s.cern.ch, cmsr2-s.cern.ch, cmsr3-s.cern.ch
+confdb10.dbHost=localhost
 confdb10.dbPort=10121
-confdb10.dbName=cms_hlt.cern.ch
-confdb10.dbUser=cms_hlt_gdrdev_w
+confdb10.dbName=cms_omds_tunnel.cern.ch
+confdb10.dbUser=cms_hlt_gdr_w
 confdb10.proxy=false
 
-confdb11.dbSetup=Offline Dev (socks tunnel)
+confdb11.dbSetup=DAQ (direct tunnel, readonly)
 confdb11.dbType=oracle
-confdb11.dbHost=10.116.96.89, 10.116.96.139, 10.116.96.105
+confdb11.dbHost=localhost
 confdb11.dbPort=10121
-confdb11.dbName=cms_hlt.cern.ch
-confdb11.dbUser=cms_hlt_gdrdev_w
-confdb11.proxy=true
+confdb11.dbName=cms_omds_tunnel.cern.ch
+confdb11.dbUser=cms_hlt_gdr_r
+confdb11.proxy=false
 
-confdb12.dbSetup=Offline Dev (direct tunnel)
+confdb12.dbSetup=Offline Dev
 confdb12.dbType=oracle
-confdb12.dbHost=localhost
+confdb12.dbHost=cmsr1-s.cern.ch, cmsr2-s.cern.ch, cmsr3-s.cern.ch
 confdb12.dbPort=10121
 confdb12.dbName=cms_hlt.cern.ch
 confdb12.dbUser=cms_hlt_gdrdev_w
 confdb12.proxy=false
 
-
-confdb13.dbSetup=DAQ3 Val
+confdb13.dbSetup=Offline Dev (socks tunnel)
 confdb13.dbType=oracle
-confdb13.dbHost=int2r-s.cern.ch
+confdb13.dbHost=10.116.96.89, 10.116.96.139, 10.116.96.105
 confdb13.dbPort=10121
-confdb13.dbName=int2r_lb.cern.ch
-confdb13.dbUser=cms_hlt_gdr_w
-confdb13.proxy=false
+confdb13.dbName=cms_hlt.cern.ch
+confdb13.dbUser=cms_hlt_gdrdev_w
+confdb13.proxy=true
 
-confdb14.dbSetup=DAQ3 Val (socks tunnel)
+confdb14.dbSetup=Offline Dev (direct tunnel)
 confdb14.dbType=oracle
-confdb14.dbHost=10.16.2.179
+confdb14.dbHost=localhost
 confdb14.dbPort=10121
-confdb14.dbName=int2r_lb.cern.ch
-confdb14.dbUser=cms_hlt_gdr_w
-confdb14.proxy=true
+confdb14.dbName=cms_hlt.cern.ch
+confdb14.dbUser=cms_hlt_gdrdev_w
+confdb14.proxy=false
 
-confdb15.dbSetup=DAQ3 Val (direct tunnel)
+
+confdb15.dbSetup=DAQ3 Val
 confdb15.dbType=oracle
-confdb15.dbHost=localhost
+confdb15.dbHost=int2r-s.cern.ch
 confdb15.dbPort=10121
 confdb15.dbName=int2r_lb.cern.ch
 confdb15.dbUser=cms_hlt_gdr_w
 confdb15.proxy=false
+
+confdb16.dbSetup=DAQ3 Val (socks tunnel)
+confdb16.dbType=oracle
+confdb16.dbHost=10.16.2.179
+confdb16.dbPort=10121
+confdb16.dbName=int2r_lb.cern.ch
+confdb16.dbUser=cms_hlt_gdr_w
+confdb16.proxy=true
+
+confdb17.dbSetup=DAQ3 Val (direct tunnel)
+confdb17.dbType=oracle
+confdb17.dbHost=localhost
+confdb17.dbPort=10121
+confdb17.dbName=int2r_lb.cern.ch
+confdb17.dbUser=cms_hlt_gdr_w
+confdb17.proxy=false


### PR DESCRIPTION
this change adds proxy / tunnel settings for the ORCOFF database (thanks Martin for the heads up and IP addresses)

