### PR TITLE
don't display `FinalPath`s in Prescales' table

### DIFF
--- a/src/confdb/data/PrescaleTable.java
+++ b/src/confdb/data/PrescaleTable.java
@@ -292,14 +292,20 @@ public class PrescaleTable
 	Iterator<Path> itP = config.pathIterator();
 	while (itP.hasNext()) {
 	    Path path = itP.next();
+
+            // if path is of type FinalPath, do not display it in the PrescaleTable,
+            // as FinalPaths cannot contain EDFilters (thus, cannot contain Prescale modules)
+            if(path.isFinalPath()) continue;
+
 	    PrescaleTableRow row = pathToRow.remove(path.name());
 	    if (row==null)
 		rows.add(new PrescaleTableRow(path.name(),prescaleCount()));
 	    else
 		rows.add(row);
-		if(path.isDatasetPath()){
-			datasetPathToRowIndex.put(path.name(),rows.size()-1);
-		}
+
+	    if(path.isDatasetPath()){
+		datasetPathToRowIndex.put(path.name(),rows.size()-1);
+	    }
 	}
 
 	//so this all rather depends on the dataset paths being correctly named


### PR DESCRIPTION
This PR aims to avoid displaying FinalPaths in the table of Path prescales ("Edit Prescales").

`FinalPath`s do not actually have any prescales as they cannot contain `EDFilter`s (thus, Prescale modules). Changing PS of a FinalPath to a value different from 1 is currently allowed, but leads to a runtime error (happened online in run 356094).

Basic testing didn't show issues with this PR, but I admit I don't know the ramifications of this change.

~~Unrelated, I also noticed an `else` statement which looks like it needs brackets (judging from the `if` condition, and the indentation of the ensuing source code).~~