### PR TITLE
let `SmartPrescaleTable` accept `TriggerResultFilter`s selecting on `DatasetPath`s

### DIFF
--- a/src/confdb/data/SmartPrescaleTable.java
+++ b/src/confdb/data/SmartPrescaleTable.java
@@ -105,7 +105,7 @@ public class SmartPrescaleTable {
                 }
             } else {
                 path = config.path(strPath);
-                if ((path != null) && (!path.isStdPath())) path = null;
+                if ((path != null) && !(path.isStdPath() || path.isDatasetPath())) path = null;
             }
         }
         return (path != null);


### PR DESCRIPTION
When the SmartPS table is opened ("Edit SmartPrescales"), the GUI checks the validity of the paths used in the `triggerConditions` parameter of every `TriggerResultsFilter` module in the menu.

This PR makes `DatasetPath`s valid in this context (they would be otherwise stripped from `triggerConditions`). See the discussion in #60 for a description of a recent use case.

resolves #60
