### PR TITLE
Updates to release `V03-04-04`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,12 @@
+2022-08-22 Marino Missiroli
+    * tag V03-04-04
+	* avoid displaying FinalPaths in the Prescales table (FinalPaths cannot be prescaled)
+	* fix to Smart-PS table to handle TriggerResultFilters selecting on DatasetPaths
+
 2022-08-02 Sam Harper
     * tag V03-04-03
 	* adding tunnel setting for ORCOFF database
-	
+
 2022-07-13 Sam Harper
     * tag V03-04-02
 	* config check introduced which means two versions of the same path now prevents the menu from saving

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-04-03
+confdb.version=V03-04-04
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/


### PR DESCRIPTION
This PR includes the updates to bump version to `V03-04-04`, which would include

* [#58](https://github.com/cms-sw/hlt-confdb/pull/58) : avoid displaying FinalPaths in the Prescales table (FinalPaths cannot be prescaled)
* [#61](https://github.com/cms-sw/hlt-confdb/pull/61) : fix to Smart-PS table to handle TriggerResultFilters selecting on DatasetPaths

@sam-harper , if you agree with this, I can merge those two PRs, then this one, and deploy the new version following the instructions in the readme.