### PR TITLE
JavaCodeExecution: added `customiseForCMSHLT2471`

### DIFF
--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -1243,7 +1243,7 @@ public class ConfDbGUI {
 
 	/** execute Java Code to manipulate Config */
 	public void openJavaCodeExecution() {
-		JavaCodeExecution execute = new JavaCodeExecution(currentConfig);
+		JavaCodeExecution execute = new JavaCodeExecution(currentConfig, importConfig);
 		execute.execute();
 
 	}


### PR DESCRIPTION
Adds customisation function to apply part of the changes requested in [CMSHLT-2471](https://its.cern.ch/jira/browse/CMSHLT-2471).

This required a small update to the constructor of the `JavaCodeExecution` class.
