### PR TITLE
improve not-a-Path definition in `triggerConditions` check

### DIFF
--- a/src/confdb/data/SmartPrescaleTable.java
+++ b/src/confdb/data/SmartPrescaleTable.java
@@ -113,7 +113,7 @@ public class SmartPrescaleTable {
 
     /**check l1 **/
     public boolean checkL1TCondExists(String strCond) {
-        return ((hasAccessToL1TResults) && strCond.substring(0, 2).equals("L1"));
+        return ((hasAccessToL1TResults) && strCond.substring(0, 3).equals("L1_"));
     }
 
     /**provide list of associated streams */

--- a/src/confdb/data/SmartPrescaleTable.java
+++ b/src/confdb/data/SmartPrescaleTable.java
@@ -204,7 +204,6 @@ public class SmartPrescaleTable {
             StringTokenizer pathTokens = new StringTokenizer(strCondition, "/ ");
             while (pathTokens.hasMoreTokens()) {
                 String strPath = pathTokens.nextToken().trim();
-                if (strPath.length() < 5) continue;
                 int g = -10000;
                 try {
                     g = Integer.parseInt(strPath);
@@ -213,6 +212,14 @@ public class SmartPrescaleTable {
                 }
                 if ((g < 0) &&
                     !strPath.equals("FALSE") &&
+                    !strPath.equals("TRUE") &&
+                    !strPath.equals("(") &&
+                    !strPath.equals(")") &&
+                    !strPath.equals("NOT") &&
+                    !strPath.equals("AND") &&
+                    !strPath.equals("OR") &&
+                    !strPath.equals("XOR") &&
+                    !strPath.equals("MASKING") &&
                     !(strPath.indexOf("*") >= 0) // quick hack to allow wildcards
                     &&
                     !checkL1TCondExists(strPath) &&


### PR DESCRIPTION
Using a recent combined table (`/dev/CMSSW_12_4_0/HLT/193`), I encountered an issue similar to the one discussed in #61.

After opening the smart-PS table, the `triggerConditions` of a Path was automatically updated replacing `MASKING` with `FALSE`, because `MASKING` was considered as the name of a Path (which obviously didn't exist).

This PR tries to fix this and improve the check of which strings correspond to non-existing Paths that should be replaced. The idea is to basically catch strings that have special meaning in the syntax of the [TriggerResultsFilter parser](https://github.com/cms-sw/cmssw/blob/dc1d492ca1d13c50b88eb48a21622dbb637d2ba3/HLTrigger/HLTcore/interface/TriggerExpressionParser.h#L25-L74).

Somewhat related, the condition to identify the string of a L1T algorithm is slightly changed (from `L1*` to `L1_*`), again to match the definition used in parser's implementation (see [here](https://github.com/cms-sw/cmssw/blob/dc1d492ca1d13c50b88eb48a21622dbb637d2ba3/HLTrigger/HLTcore/interface/TriggerExpressionParser.h#L41)).