### PR TITLE
Updates to release `V03-04-05`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-11-02 Marino Missiroli
+    * tag V03-04-05
+	* fix to Smart-PS table to improve replacement of non-existing Paths (allowing special keywords like "MASKING")
+
 2022-08-22 Marino Missiroli
     * tag V03-04-04
 	* avoid displaying FinalPaths in the Prescales table (FinalPaths cannot be prescaled)
@@ -20,7 +24,7 @@
 	* for configs with release template >=12_4_0 (except for 12_5_0_pre1) Task is now renamed
 	  ConditionalTask in python
 	* FWCore/ParameterSet updated to release CMSSW_12_4_0_pre4
-	* parser supports parsing both conditional and standard tasks (but parses them to the same 
+	* parser supports parsing both conditional and standard tasks (but parses them to the same
 	  location their type is lost)
 
 2022-04-19 Sam Harper
@@ -133,7 +137,6 @@
 	* users now can only write to the /user directory in Run3 and Dev databases
 	* updates Oracle driver to version 21c
 
-	
 2021-08-06 Philipp Brummer
     * tag V02-08-03
     * bug fix: change HtmlSwitchProducerWriter class name to match expected spelling (HTML to Html)

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-04-04
+confdb.version=V03-04-05
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/


### PR DESCRIPTION
This PR includes the updates to bump version to `V03-04-05`, which includes

* [#66](https://github.com/cms-sw/hlt-confdb/pull/66) : adds customisation function to apply part of the changes requested in [CMSHLT-2471](https://its.cern.ch/jira/browse/CMSHLT-2471)
* [#67](https://github.com/cms-sw/hlt-confdb/pull/67) : improve not-a-Path definition in `triggerConditions` check (not to mistake special keywords like "MASKING" for a non-existing Path)
