### PR TITLE
change default compression settings of `OutputModule`s

### DIFF
--- a/src/confdb/data/OutputModule.java
+++ b/src/confdb/data/OutputModule.java
@@ -51,9 +51,9 @@ public class OutputModule extends ParameterContainer implements Referencable {
 		
 		BoolParameter useCompresion = new BoolParameter("use_compression", true, false);
 		
-		StringParameter compressionAlgorithm = new StringParameter("compression_algorithm", "ZLIB", false);
+		StringParameter compressionAlgorithm = new StringParameter("compression_algorithm", "ZSTD", false);
 		
-		Int32Parameter compressionLevel = new Int32Parameter("compression_level", 1, false);
+		Int32Parameter compressionLevel = new Int32Parameter("compression_level", 3, false);
 		
 		Int32Parameter lumiSectionInterval = new Int32Parameter("lumiSection_interval", 0, false);
 


### PR DESCRIPTION
[CMSHLT-2651](https://its.cern.ch/jira/browse/CMSHLT-2651) changes the default compression settings of the HLT OutputModules.

This PR updates the constructor of the `OutputModule` class in order to use the new default values.

This way, the new default does not need to be set manually every time a new `OutputModule` is created (if non-default values are needed, one will have to edit the new `OutputModule` manually, as usual).
