### PR TITLE
Updates to release `V03-04-06`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-03-14 Marino Missiroli
+    * tag V03-04-06
+	* changed default compression settings in the constructor of the OutputModule class (new default: "ZSTD, level=3")
+
 2022-11-02 Marino Missiroli
     * tag V03-04-05
 	* fix to Smart-PS table to improve replacement of non-existing Paths (allowing special keywords like "MASKING")

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-04-05
+confdb.version=V03-04-06
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/


### PR DESCRIPTION
This PR lists the updates to bump version to `V03-04-06`, i.e.

* [#70](https://github.com/cms-sw/hlt-confdb/pull/70) : adds customisation function to aid migration of menus to release template "CMSSW_13_0_0_pre3" (by default, disabled).
* [#71](https://github.com/cms-sw/hlt-confdb/pull/71) : adds customisation function used for [CMSHLT-2641](https://its.cern.ch/jira/browse/CMSHLT-2641) (by default, disabled).
* [#72](https://github.com/cms-sw/hlt-confdb/pull/72) : adds customisation function used for [CMSHLT-2651](https://its.cern.ch/jira/browse/CMSHLT-2651) (by default, disabled).
* [#73](https://github.com/cms-sw/hlt-confdb/pull/73) : change default compression settings of `OutputModule`s (new default: "ZSTD, level 3").
