### PR TITLE
recognise `SwitchProducer`s in EventContent statements

### DIFF
--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -5787,9 +5787,12 @@ class CommandTableCellRenderer extends DefaultTableCellRenderer {
 				return this;
 
 			setBackground(Color.RED);
-			ModuleInstance instance = config.module(label);
-			if (instance == null)
+			Referencable instance = (Referencable) config.module(label);
+			if (instance == null) {
+			    instance = (Referencable) config.switchProducer(label);
+			    if (instance == null)
 				return this;
+			}
 
 			setBackground(Color.ORANGE);
 			Path[] paths = instance.parentPaths();


### PR DESCRIPTION
The GUI currently does not recognise `SwitchProducer`s when checking the validity of `keep`/`drop` statements in EventContents [1]. This PR tries to fix that [2].

Works as expected based on simple local tests.

[1]
![prePR](https://github.com/cms-sw/hlt-confdb/assets/5320055/0b1359ba-b886-4d5a-a3fd-fac78055e015)

[2]
![postPR](https://github.com/cms-sw/hlt-confdb/assets/5320055/88075446-d81f-4b23-a66a-b2aa00e561ef)
