### PR TITLE
Updates to release `V03-04-07`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-07-03 Marino Missiroli
+    * tag V03-04-07
+	* recognise SwitchProducers when coloring EventContent statements
+	* avoid exception when renaming EventContents
+
 2023-03-14 Marino Missiroli
     * tag V03-04-06
 	* changed default compression settings in the constructor of the OutputModule class (new default: "ZSTD, level=3")

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-04-06
+confdb.version=V03-04-07
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/


### PR DESCRIPTION
This PR lists the updates to bump version to `V03-04-07`, i.e.

* [#76](https://github.com/cms-sw/hlt-confdb/pull/76) : adds customisation function used for [CMSHLT-2800](https://its.cern.ch/jira/browse/CMSHLT-2800) (by default, disabled).
* [#77](https://github.com/cms-sw/hlt-confdb/pull/77) : recognise `SwitchProducer`s when coloring EventContent statements.
* [#69](https://github.com/cms-sw/hlt-confdb/pull/69) : avoid exception when renaming `EventContent`s.
