### PR TITLE
Hack to make "Output Module Inserter" support plugin-type names with `:`

### DIFF
--- a/src/confdb/gui/ConfigurationTreeActions.java
+++ b/src/confdb/gui/ConfigurationTreeActions.java
@@ -282,7 +282,7 @@ public class ConfigurationTreeActions {
 		ConfigurationTreeModel model = (ConfigurationTreeModel) tree.getModel();
 		Configuration config = (Configuration) model.getRoot();
 
-		if (templateName.indexOf(':') >= 0) {
+		if (templateName.indexOf(":") >= 0) {
 			String[] s = templateName.split(":");
 			Template template = config.release().essourceTemplate(s[1]);
 			Instance original = null;
@@ -326,7 +326,7 @@ public class ConfigurationTreeActions {
 		ConfigurationTreeModel model = (ConfigurationTreeModel) tree.getModel();
 		Configuration config = (Configuration) model.getRoot();
 
-		if (templateName.indexOf(':') > 0) {
+		if (templateName.indexOf(":") > 0) {
 			String[] s = templateName.split(":");
 			Template template = config.release().esmoduleTemplate(s[1]);
 			Instance original = null;
@@ -2011,8 +2011,7 @@ public class ConfigurationTreeActions {
 		index = 0;
 		while (ESMit.hasNext()) {
 			ESModuleInstance esmodule = ESMit.next();
-			ESModuleInstance NewModule = configurationCopy.insertESModule(index, esmodule.template().name(),
-					esmodule.name());
+			ESModuleInstance NewModule = configurationCopy.insertESModule(index, esmodule.template().name(), esmodule.name());
 			index++;
 			Iterator<Parameter> itP = esmodule.parameterIterator();
 			while (itP.hasNext()) {
@@ -3068,7 +3067,19 @@ public class ConfigurationTreeActions {
 				return false;
 			reference = config.insertOutputModuleReference(parent, index, referencedOutput);
 		} else if (type.equalsIgnoreCase("Module")) {
-			String[] s = name.split(":");
+			// The "unlikely string" hack.
+			//  Here, the variable "name" can presumably take values of the form
+			//  "pluginType", "pluginType:moduleLabel", or "copy:pluginType:moduleLabel".
+			//  Unfortunately, this convention does not take into account the fact that
+			//  pluginType itself can contain the substring "::" (e.g. plugin types with namespace specification,
+			//  like Alpaka plugins with explicit backend selection).
+			//  The hack below consists in replacing "::" in "name" with "##", before "name" is split by ":".
+			//  After that, the replacement of "::" with this unlikely string is undone in "templateName".
+			// NOTE.
+			//  This hack assumes that plugin types in CMSSW will never
+			//  have "##" in their name, since that would be invalid in C++.
+			String unlikelyStr = "##";
+			String[] s = name.replaceAll("::", unlikelyStr).split(":");
 			String templateName = "";
 			String instanceName = "";
 			boolean copy = false;
@@ -3083,7 +3094,9 @@ public class ConfigurationTreeActions {
 				templateName = s[1];
 				instanceName = s[2];
 			}
-			
+
+			templateName = templateName.replaceAll(unlikelyStr, "::");
+
 			ModuleTemplate template = config.release().moduleTemplate(templateName);
 
 			if (!copy) {


### PR DESCRIPTION
This PR is a follow-up to #85, in light of the discussion in #86.

The production HLT menus need to include plugin types with `:` in their name (e.g. `alpaka_serial_sync::*`), and the "Output Module Inserter" currently does not support adding this kind of modules via the GUI (parsing of these modules directly from python works without issue).

This PR introduces a workaround to fix this GUI issue. More details are given in the comment in the source code.

This PR is only a GUI improvement. It is not strictly needed to release a new version of the GUI with this right away, and it is a "minor" update (meaning, it does not trigger a "major" release update for the next release of this package).