### PR TITLE
instructions to request update of `ConfDB` converter at P5

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,37 @@ After deployment, make sure that changes in the `confdbv3` branch are also propa
 The two development branches should always be a superset of the stable branch.
 To deploy new versions of the non-production branches, update them appropriately
 and re-run the deployment script `./deploy.sh` from the relevant branch (so, once per branch).
+
+## online operations: request deployment of new confdb converter at P5
+
+When the python converter of `ConfDB` is updated, this is considered a "major update"
+(the `X` or `Y` in version number `X.Y.Z` need to be increased),
+and it warrants the release of a new ConfDB version.
+
+The converter used online (P5) should not differ from the one used offline.
+This means that the updated converter should be provided
+to the DAQ group, requesting to deploy it at P5.
+The steps below describe how to prepare this request.
+
+ 0. Make sure the `v3` instance of `ConfDB` is up-to-date, meaning it includes, or corresponds to, the "major update" to be propagated to DAQ.
+
+ 1. Log into `lxplus` with the `confdb` account.
+
+ 2. Go to directory where this repo is cloned (currently `~/private/hlt-confdb`).
+
+ 3. Run the script
+    ```bash
+    ./deployDAQ.py --update-hilton
+    ```
+    This creates the converter to be passed to DAQ, and used by FOG (commonly referred to by FOG as the "DAQ converter"),
+    copying it from the current version of the converter in the `v3` instance.
+    To verify that the update has worked correctly, one can check the content of the following directory.
+    ```bash
+    /afs/cern.ch/user/c/confdb/www/daq
+    ```
+    If the option `--update-hilton` is not specified, the script only creates a copy of the `v3` converter in the `daq/` directory,
+    but it does not update the version of the converter used by FOG for testing on Hilton machines.
+
+ 4. Open a JIRA ticket in the CMSHLT project to request the update of the converter used online by DAQ.
+    In this ticket, include FOG and DAQ as Components.
+    An example of such requests can be found in [CMSHLT-2347](https://its.cern.ch/jira/browse/CMSHLT-2347).

--- a/deployDAQ.py
+++ b/deployDAQ.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+import argparse
+import shutil
+import os
+"""
+this script takes the currently deployed v3 version and copies the converter
+to the daq location which the DAQ experts can pick it up
+
+once its installed in the daq, --deploy-hilton, updates the sym link and version file so it becomes availbile on the hilton by default
+
+"""
+def convert_version(in_version):   
+    return ".".join([x.lstrip("0") if x.lstrip("0")!='' else "0" for x in in_version[1:].split("-")])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='copies the main branch converter to the DAQ location')
+    parser.add_argument('--update-hilton',dest="update_hilton",action='store_true',help="also updates hilton")
+    parser.add_argument('--base-dir',dest="base_dir",default="/afs/cern.ch/user/c/confdb/www",help="confdb base directory")
+    args = parser.parse_args()
+
+    base_dir = args.base_dir
+    main_version = "v3"
+    daq_version = "daq"
+    main_dir = f"{base_dir}/{main_version}"
+    daq_dir = f"{base_dir}/{daq_version}"
+
+    version = None
+
+    converter_file = "cmssw-evf-confdb-converter"
+    with open(f"{main_dir}/confdb.version") as f:
+        for line in f.readlines():
+            if line.startswith("confdb.version="):
+                version = convert_version(line.split("=")[1].rstrip())
+                break
+
+    if version:
+        out_file = f"{daq_dir}/lib/{converter_file}-{version}.jar"
+        in_file = f"{main_dir}/lib/{converter_file}.jar"
+        shutil.copyfile(in_file,out_file)
+        print(f"deploying\n  {in_file}\nto\n  {out_file}")
+        
+        if args.update_hilton:
+            print("updating hilton")
+            if os.path.exists(f"{daq_dir}/lib/{converter_file}.jar"):
+                os.remove(f"{daq_dir}/lib/{converter_file}.jar")
+            cwd = os.getcwd()
+            os.chdir(f"{daq_dir}/lib")
+            os.symlink(f"{converter_file}-{version}.jar",
+                       f"{converter_file}.jar")
+            os.chdir(cwd)
+            shutil.copyfile(f"{main_dir}/confdb.version",f"{daq_dir}/confdb.version")
+
+    else:
+        print("version file not found, converter was not properly deployed, aborting")


### PR DESCRIPTION
This PR contains notes on how to request the update of the ConfDB converter to DAQ for the purpose of online operations (see [CMSHLT-2347](https://its.cern.ch/jira/browse/CMSHLT-2347) for an example of such requests).

This text might need corrections, as it is just my understanding of the procedure, not something I truly know.

This kind of requests are not normally done by STORM, but I thought writing this here would not hurt.

This PR also adds a script by @Sam-Harper (`deployDAQ.py`) used to facilitate this kind of procedure.