### PR TITLE
`JavaCodeExecution`: add `printModuleLabels`, `addPSet_optionsAccelerators` and `alignPathVersionNumbers`

### DIFF
--- a/src/confdb/gui/JavaCodeExecution.java
+++ b/src/confdb/gui/JavaCodeExecution.java
@@ -36,6 +36,7 @@ public class JavaCodeExecution {
 
 	public void execute() {
 		System.out.println("\n[JavaCodeExecution] start:");
+		// addPSet_optionsAccelerators();
 		// customiseForCMSHLT2981();
 		// customiseForCMSHLT2980();
 		// customiseForCMSHLT2913();
@@ -154,7 +155,24 @@ public class JavaCodeExecution {
 		}
 	}
 
-    
+        // Add global PSet named options with its accelerators parameter in order to steer GPU offloading
+        // See CMSHLT-3126
+        void addPSet_optionsAccelerators() {
+          PSetParameter pset = config.pset("options");
+          if (pset == null) {
+            pset = new PSetParameter("options", "", false);
+            pset.addParameter(new VStringParameter("accelerators", "*", false));
+            config.insertPSet(pset);
+          }
+          else {
+            Parameter acc = pset.parameter("accelerators");
+            if (acc == null) {
+              pset.addParameter(new VStringParameter("accelerators", "*", false));
+              config.psets().setHasChanged();
+            }
+          }
+        }
+
         // CMSHLT-2981: Removal of deprecated GRun Paths (=> combined table
         private void customiseForCMSHLT2981() {
 	    

--- a/src/confdb/gui/JavaCodeExecution.java
+++ b/src/confdb/gui/JavaCodeExecution.java
@@ -36,6 +36,7 @@ public class JavaCodeExecution {
 
 	public void execute() {
 		System.out.println("\n[JavaCodeExecution] start:");
+		// printModuleLabels();
 		// addPSet_optionsAccelerators();
 		// customiseForCMSHLT2981();
 		// customiseForCMSHLT2980();
@@ -154,6 +155,18 @@ public class JavaCodeExecution {
 			}
 		}
 	}
+
+        // Print label of every "Module" in the configuration
+        // (EDProducers, EDFilters, EDAnalyzer and possibly SwitchProducer branches)
+        // See CMSHLT-3131
+        void printModuleLabels() {
+          Integer numOfModules = config.moduleCount();
+          for (int i = 0; i < numOfModules; i++) {
+            ModuleInstance module = config.module(i);
+            System.out.println(module.name());
+          }
+          System.out.println("\nTotal Number of Modules: " + numOfModules.toString());
+        }
 
         // Add global PSet named options with its accelerators parameter in order to steer GPU offloading
         // See CMSHLT-3126


### PR DESCRIPTION
This PR adds three utility functions developed recently for different reasons. They are all disabled by default.

 - `addPSet_optionsAccelerators` adds a global PSet named options with its accelerators parameter, in order to steer GPU offloading (see [See CMSHLT-3126]()).

 - `printModuleLabels` prints the label of every "Module" in the configuration (EDProducers, EDFilters, EDAnalyzer and possibly SwitchProducer branches) (see [CMSHLT-3131]()).

 - `alignPathVersionNumbers` renames the Paths in the configuration changing their version numbers in order to match the version numbers of the Paths in "importConfig" (the configuration opened in parallel using the "Import" functionality of the GUI). This can be useful when one wants to built a configuration to be compared to an older, or newer, one whose Paths have different version numbers. The Diff functionality of the legacy GUI (i.e. this one) does not ignore Path-version numbers, so a meaningful Diff can only be done after the Path-version numbers are the same in two given configurations. The web-based version of ConfDB provides a better Diff tool ([link](https://hlt-config-editor-confdbv3.app.cern.ch/diff)), capable of ignoring Path-version numbers.
