### PR TITLE
Fixing bugs with process name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-04-17 Sam Harper
+    * tag V03-05-02
+    * process name now copies across when "open from different db"
+    * process name field updates when focus is lost and not only when enter is pressed
+     
+
 2024-03-11 Marino Missiroli, Marco Musich
     * tag V03-05-01
         * Hack to make "Output Module Inserter" support plugin-type names with : 

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-05-01
+confdb.version=V03-05-02
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -2167,6 +2167,7 @@ public class ConfDbGUI {
 			ReleaseMigrator releaseMigrator = new ReleaseMigrator(otherDBConfig, config);
 			releaseMigrator.migrate();
 			setCurrentConfig(config);
+            jTextFieldProcess.setText(otherDBConfig.configInfo().processName());
 			try {
 				otherDatabase.disconnect();
 			} catch (DatabaseException e) {

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -272,12 +272,20 @@ public class ConfDbGUI {
 
 		frame.setContentPane(jPanelContentPane);
 		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-
+        //only works if enter is pressed
 		jTextFieldProcess.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				jButtonProcessActionPerformed(e);
 			}
 		});
+        jTextFieldProcess.addFocusListener(new FocusListener() {
+            public void focusGained(FocusEvent e) {
+             
+            }
+            public void focusLost(FocusEvent e) {
+                updateProcessName();
+            }
+        });
 		jButtonRelease.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				jButtonReleaseActionPerformed(e);
@@ -3624,12 +3632,19 @@ public class ConfDbGUI {
 	//
 
 	private void jButtonProcessActionPerformed(ActionEvent e) {
-		String processName = jTextFieldProcess.getText();
-		if (processName.length() == 0 || processName.indexOf('_') >= 0)
-			jTextFieldProcess.setText(currentConfig.processName());
-		else
-			currentConfig.setHasChanged(true);
+		updateProcessName();
 	}
+
+    private void updateProcessName(){
+        String processName = jTextFieldProcess.getText();
+        if (!processName.equals(currentConfig.processName())) {
+            
+            if (processName.length() == 0 || processName.indexOf('_') >= 0)
+                    jTextFieldProcess.setText(currentConfig.processName());
+            else
+                currentConfig.setHasChanged(true);
+        }
+    }
 
 	private void jButtonReleaseActionPerformed(ActionEvent e) {
 		if (currentConfig.isEmpty())


### PR DESCRIPTION
This fixes

https://github.com/cms-sw/hlt-confdb/issues/87: which was when you use open different db, the process name is not copied
https://github.com/cms-sw/hlt-confdb/issues/89: which was more of a usability issue than a bug, you had to press enter to trigger it but its really not obvious so now works on focus change. 