### PR TITLE
`JavaCodeExecution`: fix `customiseForCMSHLT3132` (skip `HLTPrescaler`)

### DIFF
--- a/src/confdb/gui/JavaCodeExecution.java
+++ b/src/confdb/gui/JavaCodeExecution.java
@@ -182,6 +182,10 @@ public class JavaCodeExecution {
                   continue;
                 }
 
+                if (module.template().name().equals("HLTPrescaler")) {
+                  continue;
+                }
+
                 System.out.printf("[customiseForCMSHLT3132] CHANGE #"+numChangesMod.toString()+":");
                 System.out.println(" (Old Name => New Name) \""+oldName+"\" => \""+newName+"\"");
                 try {


### PR DESCRIPTION
Bugfix for the customisation function introduced in #92.

The renaming implemented in that function should not be applied to instances of the `HLTPrescaler` plugin: the labels of those modules are solely, and uniquely, defined by the name of the corresponding Path.
