### PR TITLE
change max number of split PDs from 32 to 64

### DIFF
--- a/src/confdb/gui/SplitDatasetDialog.java
+++ b/src/confdb/gui/SplitDatasetDialog.java
@@ -78,7 +78,7 @@ public class SplitDatasetDialog extends JDialog {
 	//
 	private void jTextFieldTextFileNumberToSplitUpdate(DocumentEvent e) {
         int nrToSplit = getNrToSplit();
-        if(nrToSplit>0 && nrToSplit<=32){
+        if(nrToSplit>0 && nrToSplit<=64){
 			jButtonOK.setEnabled(true);
         }else{
 			jButtonOK.setEnabled(false);
@@ -94,7 +94,7 @@ public class SplitDatasetDialog extends JDialog {
 		jButtonOK = new javax.swing.JButton();
 		jButtonCancel = new javax.swing.JButton();
 
-		jLabelNrInstanceText.setText("Number of Dataset Instances (must be in range 1 to 32 inclusive)");
+		jLabelNrInstanceText.setText("Number of Dataset Instances (must be in range 1 to 64 inclusive)");
 		
 		jTextFieldNumberToSplit.getDocument().addDocumentListener(new DocumentListener() {
 			public void insertUpdate(DocumentEvent e) {


### PR DESCRIPTION
[CMSHLT-3326](https://its.cern.ch/jira/browse/CMSHLT-3326) describes a situation where we might need to split a Primary Dataset by more than 32, which is the max number currently allowed by the GUI (thanks to @trocino for reminding me of that). Beyond the test discussed in that ticket, we may need more than 32 split PDs also in the upcoming HI run, depending on what the final output bandwidth will be.

The update on the GUI side seems simple, but I'm no expert.

@Sam-Harper , what do you think ?