### PR TITLE
removing whitespace in  VEventID  parsing

### DIFF
--- a/src/confdb/data/VEventIDParameter.java
+++ b/src/confdb/data/VEventIDParameter.java
@@ -169,8 +169,8 @@ class EventID
 	String[] strValues = valueAsString.split(":");
 	if (strValues.length==2) {
 	    try {
-		this.runNumber = new Integer(strValues[0]);
-		this.evtNumber = new Integer(strValues[1]);
+		this.runNumber = new Integer(strValues[0].trim());
+		this.evtNumber = new Integer(strValues[1].trim());
 	    }
 	    catch (NumberFormatException e) {
 		throw new DataException("EventID ctor failed: " + e.getMessage());


### PR DESCRIPTION
This PR fixes an issue in the VEventID parsing where it does not handle whitespace around the ":" 

This is particularly an issue as when VEventID stringifies its representation it adds whitespace around the ":"

So if a template includes a VEventID parameter and it its copied from another database, part of that copy process is stringifying the parameters and then all of a sudden you cant open any menu with that template. 

This will need deployment to a the DAQ and will require a new major version as per policy. Although it has no output changes on the menu. 

Will prep those changes shortly

