### PR TITLE
`JavaCodeExecution`: add `customiseForCMSHLT3326`

### DIFF
--- a/src/confdb/gui/JavaCodeExecution.java
+++ b/src/confdb/gui/JavaCodeExecution.java
@@ -36,6 +36,7 @@ public class JavaCodeExecution {
 
 	public void execute() {
 		System.out.println("\n[JavaCodeExecution] start:");
+		// customiseForCMSHLT3326();
 		// customiseForCMSHLT3132();
 		// printModuleLabels();
 		// addPSet_optionsAccelerators();
@@ -157,6 +158,11 @@ public class JavaCodeExecution {
 			}
 		}
 	}
+
+        // CMSHLT-3326: Addition of TestHLTPhysics* streams for DAQ transfer-system tests
+        private void customiseForCMSHLT3326() {
+          addSplitStreams("[customiseForCMSHLT3326]", "hltEventContentAForPP", "TestHLTPhysics", 0, 19);
+        }
 
         // CMSHLT-3132: Rename Alpaka modules incl. "CPUOnly -> SerialSync"
         private void customiseForCMSHLT3132() {


### PR DESCRIPTION
This PR adds a customisation function used in [CMSHLT-3326](https://its.cern.ch/jira/browse/CMSHLT-3326).

This is just for convenience (this function may be useful to FOG again for [CMSHLT-3358](https://its.cern.ch/jira/browse/CMSHLT-3358)).

By default, the customisation function is disabled.
