### PR TITLE
`readme`: added link to instructions for deployment to DAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,6 @@ The steps below describe how to prepare this request.
 
  4. Open a JIRA ticket in the CMSHLT project to request the update of the converter used online by DAQ.
     In this ticket, include FOG and DAQ as Components.
-    An example of such requests can be found in [CMSHLT-2347](https://its.cern.ch/jira/browse/CMSHLT-2347).
+    Examples of such requests can be found in
+    [CMSHLT-2347](https://its.cern.ch/jira/browse/CMSHLT-2347) and
+    [CMSHLT-3114](https://its.cern.ch/jira/browse/CMSHLT-3114).


### PR DESCRIPTION
Just adding an extra link in the section of the readme that describes how to prepare the deployment of a new version of the ConfDB converter to the central DAQ.