### PR TITLE
place `OutputModule`s on `EndPath`s (not `FinalPath`s) in HLT configs

### DIFF
--- a/src/confdb/data/Configuration.java
+++ b/src/confdb/data/Configuration.java
@@ -1749,7 +1749,7 @@ public class Configuration implements IConfiguration {
 		if(outPath==null){
 
 			outPath = insertPath(pathCount(),stream.outputPathName());
-			outPath.setAsFinalPath();
+			outPath.setAsEndPath();
 			insertOutputModuleReference(outPath,0,stream.outputModule());
 			return true;			
 		} else if(!outPath.isOutputPathOfStream(stream)){
@@ -1761,7 +1761,7 @@ public class Configuration implements IConfiguration {
 
 				removePath(outPath);
 				outPath = insertPath(index,stream.outputPathName());
-				outPath.setAsFinalPath();	
+				outPath.setAsEndPath();
 				insertOutputModuleReference(outPath,0,stream.outputModule());
 				return true;
 			}else{

--- a/src/confdb/data/ConfigurationModifier.java
+++ b/src/confdb/data/ConfigurationModifier.java
@@ -286,7 +286,7 @@ public class ConfigurationModifier implements IConfiguration {
 			Path out = new Path("output");
 			ModuleInstance outputI = modifications.outputModuleToBeAdded("out");
 			outputI.createReference(out, 0);
-			out.setAsFinalPath();
+			out.setAsEndPath();
 			paths.add(out);
 		}
 

--- a/src/confdb/data/Path.java
+++ b/src/confdb/data/Path.java
@@ -305,6 +305,14 @@ public class Path extends ReferenceContainer {
 		return name.replaceAll("_v[0-9]+$","");
 	}
 
+	/**
+	 * Returns True if the Path contains at least one module of type HLTPrescaler, False otherwise.
+	 */
+        public boolean hasHLTPrescalerModule(){
+                ArrayList<ModuleInstance> hltPreModArray = moduleArray("HLTPrescaler");
+                return (hltPreModArray.size() > 0);
+        }
+
 	/** set the name and propagate it to all relevant modules */
 	public void setNameAndPropagate(String name) throws DataException {
 		String oldName = name();

--- a/src/confdb/data/Path.java
+++ b/src/confdb/data/Path.java
@@ -152,13 +152,13 @@ public class Path extends ReferenceContainer {
 
 	/**
 	 * a path is a valid output path of a stream if
-	 * 1) it is a final path
+	 * 1) it is a EndPath or FinalPath
 	 * 2) it contains exactly one entry
 	 * 3) that entry is that streams output module
 	 * if no stream is specified then it just looks for one output module to be present
 	 */
 	public boolean isOutputPathOfStream(Stream stream){
-		if(isFinalPath() && entryCount()==1){			
+		if((isEndPath() || (isFinalPath() && entryCount()==1)) && hasOutputModule()){
 			Iterator<OutputModule> outputIt = outputIterator();
 			if(outputIt.hasNext() && (stream==null || outputIt.next()==stream.outputModule())){
 				return true;

--- a/src/confdb/data/PrescaleTable.java
+++ b/src/confdb/data/PrescaleTable.java
@@ -293,9 +293,9 @@ public class PrescaleTable
 	while (itP.hasNext()) {
 	    Path path = itP.next();
 
-            // if path is of type FinalPath, do not display it in the PrescaleTable,
-            // as FinalPaths cannot contain EDFilters (thus, cannot contain Prescale modules)
-            if(path.isFinalPath()) continue;
+            // If the Path does not contain any HLTPrescaler modules,
+            // do not show it in the PrescaleTable
+            if(!path.hasHLTPrescalerModule()) continue;
 
 	    PrescaleTableRow row = pathToRow.remove(path.name());
 	    if (row==null)

--- a/src/confdb/gui/CommandActionListener.java
+++ b/src/confdb/gui/CommandActionListener.java
@@ -38,6 +38,7 @@ public class CommandActionListener implements ActionListener
     private static final String cmdSmartVersions    = "Smart Path Versioning";
     private static final String cmdSmartRenaming    = "Smart Renaming";
     private static final String cmdConvertToTasks   = "Taskify";
+    private static final String cmdConvertFPsToEPs  = "Convert FinalPaths to EndPaths";
     private static final String cmdPSEditor         = "Edit Prescales";
     private static final String cmdSPSEditor        = "Edit SmartPrescales";
     private static final String cmdMLEditor         = "Edit MessageLogger";
@@ -89,13 +90,14 @@ public class CommandActionListener implements ActionListener
 	if (command.equals(cmdSmartVersions))    app.smartVersionsConfigurations();
 	if (command.equals(cmdSmartRenaming))    app.smartRenamingConfigurations();
     if (command.equals(cmdConvertToTasks))   app.convertToTasks();
+        if (command.equals(cmdConvertFPsToEPs))  app.convertFinalPathsToEndPaths();
 	if (command.equals(cmdPSEditor))         app.openPrescaleEditor();
 	if (command.equals(cmdSPSEditor))        app.openSmartPrescaleEditor();
 	if (command.equals(cmdMLEditor))         app.openMessageLoggerEditor();
 	if (command.equals(cmdJavaCode))         app.openJavaCodeExecution();
 	if (command.equals(cmdUPEditor))         app.addUntrackedParameter();
     if (command.equals(cmdResetGUI))         app.resetGUI();
-	
+
 	if (command.equals(cmdTrack))            app.setOptionTrackInputTags(source.isSelected());
 	if (command.equals(cmdEnableClone))      app.setEnablePathCloning(source.isSelected());
 

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -1376,6 +1376,35 @@ public class ConfDbGUI {
 		
 	}
 
+	public void convertFinalPathsToEndPaths() {
+          if (currentConfig == null) {
+            return;
+          }
+
+          ArrayList<Path> pathsToRm = new ArrayList<Path>();
+          Iterator<Path> itP = currentConfig.pathIterator();
+          while (itP.hasNext()) {
+            Path p0 = itP.next();
+            if(p0 != null && p0.isFinalPath()) {
+              pathsToRm.add(p0);
+            }
+          }
+
+          Integer numChanges = 0;
+          for (Path aPath : pathsToRm) {
+            System.out.printf("\n[convertFinalPathsToEndPaths] #"+numChanges.toString()+" Path Removed: "+aPath.name());
+            currentConfig.removePath(aPath);
+            ++numChanges;
+          }
+
+          System.out.println("\n[convertFinalPathsToEndPaths] Number of FinalPaths removed: "+numChanges.toString());
+
+          if (numChanges > 0) {
+            currentConfig.generateOutputPaths();
+            System.out.println("\n[convertFinalPathsToEndPaths] EndPaths with OutputModules generated !");
+          }
+	}
+
 	/** search/replace parameters in the current configuration */
 	public void searchAndReplace() {
 		if (currentConfig.isEmpty())

--- a/src/confdb/gui/ConfigChecks.java
+++ b/src/confdb/gui/ConfigChecks.java
@@ -320,7 +320,7 @@ class ConfigChecks {
             for(String error : errors ){
                 errStr+="\n"+error;
             }         
-            String msg = new String("The current config has streams with a DatasetPath which do not have a StreamOutputPath.\nA stream output path is named <StreamName>Output, is a FinalPath and contains only the streams output module.\nThese are automatically generated but this generation can fail if a path exists of the same name.\nPlease delete/rename the offending paths if they exist and then right click on streams and select \"Generate Output Paths\"\n");
+            String msg = new String("The current config has streams with a DatasetPath which do not have a StreamOutputPath.\nA stream output path is named <StreamName>Output, is an EndPath or FinalPath which contains the stream's output module (if it is a FinalPath, the output module is the only module allowed).\nThese are automatically generated but this generation can fail if a path exists of the same name.\nPlease delete/rename the offending paths if they exist and then right click on streams and select \"Generate Output Paths\"\n");
 			msg+=errStr;			
 			JTextArea textArea = new JTextArea(msg);
 			JScrollPane scrollPane = new JScrollPane(textArea);  

--- a/src/confdb/gui/MenuBar.java
+++ b/src/confdb/gui/MenuBar.java
@@ -42,6 +42,7 @@ public class MenuBar {
 	private static final String toolMenuSmartVersions = "Smart Path Versioning";
 	private static final String toolMenuSmartRenaming = "Smart Renaming";
 	private static final String toolMenuConvertToTasks = "Taskify";
+	private static final String toolMenuConvertFPsToEPs = "Convert FinalPaths to EndPaths";
 	private static final String toolMenuPSEditor = "Edit Prescales";
 	private static final String toolMenuSPSEditor = "Edit SmartPrescales";
 	private static final String toolMenuMLEditor = "Edit MessageLogger";
@@ -81,6 +82,7 @@ public class MenuBar {
 	private JMenuItem toolMenuSmartVersionsItem = null;
 	private JMenuItem toolMenuSmartRenamingItem = null;
 	private JMenuItem toolMenuConvertToTasksItem = null;
+	private JMenuItem toolMenuConvertFPsToEPsItem = null;
 	private JMenuItem toolMenuReplaceItem = null;
 	private JMenuItem toolMenuPSEditorItem = null;
 	private JMenuItem toolMenuSPSEditorItem = null;
@@ -127,6 +129,7 @@ public class MenuBar {
 		toolMenuSmartVersionsItem.setEnabled(true);
 		toolMenuSmartRenamingItem.setEnabled(true);
 		toolMenuConvertToTasksItem.setEnabled(true);
+		toolMenuConvertFPsToEPsItem.setEnabled(true);
 		toolMenuPSEditorItem.setEnabled(true);
 		toolMenuSPSEditorItem.setEnabled(true);
 		toolMenuMLEditorItem.setEnabled(true);
@@ -151,6 +154,7 @@ public class MenuBar {
 		toolMenuSmartVersionsItem.setEnabled(false);
 		toolMenuSmartRenamingItem.setEnabled(false);
 		toolMenuConvertToTasksItem.setEnabled(false);
+		toolMenuConvertFPsToEPsItem.setEnabled(false);
 		toolMenuReplaceItem.setEnabled(false);
 		toolMenuPSEditorItem.setEnabled(false);
 		toolMenuSPSEditorItem.setEnabled(false);
@@ -287,6 +291,10 @@ public class MenuBar {
 		toolMenuConvertToTasksItem.setActionCommand(toolMenuConvertToTasks);
 		toolMenuConvertToTasksItem.addActionListener(listener);
 		toolMenu.add(toolMenuConvertToTasksItem);
+		toolMenuConvertFPsToEPsItem = new JMenuItem(toolMenuConvertFPsToEPs);
+		toolMenuConvertFPsToEPsItem.setActionCommand(toolMenuConvertFPsToEPs);
+		toolMenuConvertFPsToEPsItem.addActionListener(listener);
+		toolMenu.add(toolMenuConvertFPsToEPsItem);
 		toolMenuReplaceItem = new JMenuItem(toolMenuReplace, KeyEvent.VK_R);
 		toolMenuReplaceItem.setActionCommand(toolMenuReplace);
 		toolMenuReplaceItem.addActionListener(listener);


### PR DESCRIPTION
This PR tries to solve #101.

 - In the steps generating "stream paths" containing `OutputModule`s, the call to `setAsFinalPath()` is replaced by `setAsEndPath()`.
 - The button "Convert FinalPaths to EndPaths" is added to the GUI: clicking it removes existing `FinalPath`s, and runs the `ConfDBGUI::generateOutputPaths()` routine, adding any missing "stream paths" as `EndPath`s.

As a test, I copied `/dev/CMSSW_15_0_0/HLT/V12`, applied the routine in this PR, and created subtables in
```
/users/missirol/test/dev/CMSSW_15_0_0/tmp/250303_removeFinalPaths/Test02/HLT
```
At first glance, the output looks as expected. I did not perform any runtime tests with `cmsRun`.

For now, I decided not to complicate the code base with extra checks on whether or not
 - (a) the config contains a mix of `FinalPath`s and `EndPath`s
 - (b) the config contains `FinalPath`s even if the release template belongs to, say, `15_0_X` or higher.

(a) is possible if one takes an existing config, and manually adds a new stream (with this PR). (b) is what we have now, and it can happen in the future if one migrates an old config to a newer template.

I think (a) and (b) will work okay in CMSSW, as long as the release supports `FinalPath`s.
 - Once `FinalPath` is removed in future CMSSW releases, users would get a runtime error if trying to run such a config in said release. I think the likelihood of this problem is small enough that this could be dealt with at the "user support" level (without extra ad-hoc checks inside the GUI).
 - I probably didn't think of all possible use cases, and I'm open to suggestions.

The idea is to move from `FinalPath`s to `EndPath`s before the release of first 2025 pp menu (April ~21).
