### PR TITLE
PSEditor Bug Fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2025-03-06 Sam Harper
+    * tag V03-06-02
+	* bug fixes for the ps editor 
+	    * adds prescale module to the dummy paths
+		* properly migrates between dbs
+		* fixes issue reading legacy ps csv files
+
 2025-03-06 Sam Harper, Marino Missiroli
     * tag V03-06-01
 	* JavaCodeExecution: add customiseForCMSHLT3326

--- a/src/conf/confdb.version
+++ b/src/conf/confdb.version
@@ -1,3 +1,3 @@
-confdb.version=V03-06-01
+confdb.version=V03-06-02
 confdb.contact=sandro.ventura@cern.ch
 confdb.url=https://confdb.web.cern.ch/confdb/v3/

--- a/src/confdb/converter/PrescaleEditorConverter.java
+++ b/src/confdb/converter/PrescaleEditorConverter.java
@@ -129,14 +129,14 @@ public class PrescaleEditorConverter {
             config.initialize(cfgInfo, release);
 
             ArrayList<String> pathNames = getPathNamesFromCSVFile(pstblfile);
-
-            ModuleInstance module = config.insertModule("HLTBool", "hltBoolTrue");
+            
             for (String pathName : pathNames) {
                 if (pathName.endsWith("_v")) {
                     pathName = pathName + "1";
                }
-                Path path = config.insertPath(config.pathCount(), pathName);
-                config.insertModuleReference(path, 0, module);
+                Path path = config.insertPath(config.pathCount(), pathName);            
+                ModuleInstance prescaler = config.insertModule("HLTPrescaler", Path.hltPrescalerLabel(pathName));
+                config.insertModuleReference(path, 0, prescaler);
             }
             config.insertService(0, "PrescaleService");
 

--- a/src/confdb/gui/ConfDbGUI.java
+++ b/src/confdb/gui/ConfDbGUI.java
@@ -1273,8 +1273,14 @@ public class ConfDbGUI {
 				return;
 			}
 			System.out.println("pscfg "+psCfgInfo.name()+" "+psCfgInfo.parentDir().name()+" "+psCfgInfo.version());
-			SoftwareRelease psRelease = new SoftwareRelease(this.currentRelease);
-			Configuration psCfg = psSourceDB.loadConfiguration(psCfgInfos.get(0),psRelease);
+			SoftwareRelease psReleaseTmp = new SoftwareRelease();
+			Configuration psCfgTmp = psSourceDB.loadConfiguration(psCfgInfos.get(0),psReleaseTmp);
+			SoftwareRelease psRelease = new SoftwareRelease(currentRelease);
+			Configuration psCfg = new Configuration(psCfgInfos.get(0),psRelease);
+			ReleaseMigrator releaseMigrator = new ReleaseMigrator(psCfgTmp,psCfg);
+			releaseMigrator.migrate();
+
+
 
 			ArrayList<String> pathsMissingInPSCfg = psCfg.pathsMissing(currentConfig,true).stream().filter(
 					pathName -> currentConfig.path(pathName,true).hasPrescaler()

--- a/src/confdb/gui/PrescaleTableModel.java
+++ b/src/confdb/gui/PrescaleTableModel.java
@@ -200,7 +200,8 @@ public class PrescaleTableModel extends AbstractTableModel {
 					//opps, first line wasnt tablename, it was the columns
 					//so we need to reset the scanner
 					prescaleTable.setExternalTableName("");
-					tableScanner.reset();
+					tableScanner.close();
+					tableScanner = new Scanner(new FileInputStream(fileName), "UTF-8");
 				}
 			}	
 


### PR DESCRIPTION
This fixes three bugs

1. old style ps csv reading now works
2. issue where migrating across dbs was not done correctly
3. puts the prescaler modules on the dummy paths which is now necessary due to https://github.com/cms-sw/hlt-confdb/pull/103