### PR TITLE
fixing issue for smart prescaler rendering

### DIFF
--- a/src/confdb/data/PrescaleTable.java
+++ b/src/confdb/data/PrescaleTable.java
@@ -29,6 +29,8 @@ public class PrescaleTable
 	//this allows us to determine which other rows need to be edited when this one is
 	protected ArrayList<ArrayList<Integer> > rowSiblings = new ArrayList<ArrayList<Integer>>();
 
+	protected boolean requirePathsToHavePrescaler = true;
+
 	//if an external tool has provided the prescales, the name of the table is stored here
 	//this should be empty otherewise and its cleared on  update of the prescale service
 	protected String externalTableName = new String();
@@ -50,6 +52,16 @@ public class PrescaleTable
     {
 	initialize(config);
     }
+
+	/** constructor with option to require paths to have prescaler 
+	 * neeed by smart prescaler
+	 */ 
+	public PrescaleTable(IConfiguration config, boolean requirePathsToHavePrescaler)
+	{
+		this.requirePathsToHavePrescaler = requirePathsToHavePrescaler;
+		initialize(config);
+	}
+	 
     
     /** NULL CONSTRUCTOR. To allow different construction in subclass. */
     protected PrescaleTable() {} 
@@ -338,7 +350,10 @@ public class PrescaleTable
 
             // If the Path does not contain any HLTPrescaler modules,
             // do not show it in the PrescaleTable
-            if(!path.hasHLTPrescalerModule()) continue;
+			// okay but turns out this is used by the smart prescale service
+			// which CAN have paths without prescale modules in it
+			// so this needs to be optional
+            if(this.requirePathsToHavePrescaler && !path.hasHLTPrescalerModule()) continue;
 
 	    PrescaleTableRow row = pathToRow.remove(path.name());
 	    if (row==null)

--- a/src/confdb/gui/SmartPrescaleDialog.java
+++ b/src/confdb/gui/SmartPrescaleDialog.java
@@ -281,7 +281,7 @@ class SmartPrescaleTableModel extends AbstractTableModel {
 	public void initialize(IConfiguration config, ModuleInstance module, SmartPrescaleTable smartPrescaleTable) {
 		this.config = config;
 		this.module = module;
-		prescaleTable = new PrescaleTable(config);
+		prescaleTable = new PrescaleTable(config,false);
 		this.smartPrescaleTable = smartPrescaleTable;
 		fireTableStructureChanged();
 		fireTableDataChanged();


### PR DESCRIPTION
as reported in [mattermost](https://mattermost.web.cern.ch/cms-tsg/pl/wxchrms1uid49xxy6sew9xobda), the smart prescale rendering has been an issue recently. 

This MR address it which was introduced by https://github.com/cms-sw/hlt-confdb/pull/103

What https://github.com/cms-sw/hlt-confdb/pull/103 did was limit paths in the prescale table to only those which had a prescaler module which is reasonable. 

The issue is that the smart prescaler also used an instance of the prescale table to track its prescales. And things in a smart prescaler dont need a prescaler themselves.

For example HLTriggerFirstPath is in the smart prescaler hltAlCaPFJet40GPUUoxCPUFilter. But its not in its local copy of its prescale table and thus when we try to access it, it throws an uncaught exception. 

The bandaid solution I did was make it configurable to whether a path has to have a prescaler to be added to the ps table. This is by default true so keeps the old behaviour everwhere except for the smart prescaler which sets this to false.

I'm open to a name change of this variable, the other one Iwas thinking of was "smartPrescalerMode"  as it makes it clear why we are using it. But figured it would be better to be descriptive of what we were doing rather than why with why in the comments.

Finally while I've tested that this works, I havent giving this fix a lot of deep thought so buyer beware. 


