### PR TITLE
futher smart prescale render fix  

### DIFF
--- a/src/confdb/gui/SmartPrescaleDialog.java
+++ b/src/confdb/gui/SmartPrescaleDialog.java
@@ -173,7 +173,6 @@ public class SmartPrescaleDialog extends JDialog {
 	private void updateMainPanel() {
 		module = config.module((String) jComboBoxModule.getSelectedItem());
 		int i = jComboBoxModule.getSelectedIndex();
-		System.out.println(module.name() + " " + smartPrescaleTable.get(i).module.name() + " " + i);
 		smartTableModel.updateSmartPrescaleWindow(module, smartPrescaleTable.get(i));
 	}
 
@@ -290,8 +289,8 @@ class SmartPrescaleTableModel extends AbstractTableModel {
 	/** update the SmartPrescale Window */
 	public void updateSmartPrescaleWindow(ModuleInstance module, SmartPrescaleTable smartPrescaleTable) {
 		this.module = module;
-		this.smartPrescaleTable = smartPrescaleTable;
-		prescaleTable = new PrescaleTable(config);
+		this.smartPrescaleTable = smartPrescaleTable;		
+		prescaleTable = new PrescaleTable(config,false);
 		fireTableStructureChanged();
 		fireTableDataChanged();
 	}


### PR DESCRIPTION
The fix in https://github.com/cms-sw/hlt-confdb/pull/111 was not complete

What I had missed is that the smart ps table recreates the pstable on any change. So navigating back to the hltAlCaPFJet40GPUxorCPUFilter would also cause a crash. I also removed some debugging output as well

This resolves the issue. Once this is merged, I also plan to create a new version which will be a seperate PR. 