### PR TITLE
remove `missirol` from `UserPermissionsManager.admins`

### DIFF
--- a/src/confdb/gui/UserPermissionsManager.java
+++ b/src/confdb/gui/UserPermissionsManager.java
@@ -36,8 +36,6 @@ public class UserPermissionsManager {
 		this.admins.add("sdonato");
 		// Sam Harper
 		//this.admins.add("sharper");
-		// Marino Missiroli
-		this.admins.add("missirol");
 		// Marco Musich
 		this.admins.add("musich");
         // Mateusz Zarucki


### PR DESCRIPTION
Removing my username from the list of usernames with administrator rights.

Tested locally that the GUI works okay with this change.
