### PR TITLE
allow `::` in `ESModule` types

### DIFF
--- a/src/confdb/gui/ConfigurationTreeActions.java
+++ b/src/confdb/gui/ConfigurationTreeActions.java
@@ -326,7 +326,7 @@ public class ConfigurationTreeActions {
 		ConfigurationTreeModel model = (ConfigurationTreeModel) tree.getModel();
 		Configuration config = (Configuration) model.getRoot();
 
-		if (templateName.indexOf(":") > 0) {
+		if (templateName.indexOf(":") > 0 && !templateName.matches("^[a-zA-Z_][a-zA-Z0-9_]*::.*")) {
 			String[] s = templateName.split(":");
 			Template template = config.release().esmoduleTemplate(s[1]);
 			Instance original = null;


### PR DESCRIPTION
Fix suggested by @PietroGru.
Otherwise trying to insert `sistrip::SiStripClusterizerConditionsESProducerAlpaka` in the ESModules list results in:

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "confdb.data.Template.instance(String)" because "template" is null
        at confdb.gui.ConfigurationTreeActions.insertESModule(ConfigurationTreeActions.java:334)
        at confdb.gui.ESModuleMenuListener.actionPerformed(ConfigurationTreeMouseListener.java:2341)
        at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
...
```
Tested successfully at `/users/STORM/CMSSW_16_0_0/etc/HLT/V1`
