### PR TITLE
add customization function to customize NGT demonstrator menus

### DIFF
--- a/src/confdb/gui/JavaCodeExecution.java
+++ b/src/confdb/gui/JavaCodeExecution.java
@@ -36,6 +36,7 @@ public class JavaCodeExecution {
 
 	public void execute() {
 		System.out.println("\n[JavaCodeExecution] start:");
+		// customizeNGTDemonstratorMenu();
 		// customiseForCMSHLT3395();
 		// customiseForCMSHLT3326();
 		// customiseForCMSHLT3132();
@@ -2388,4 +2389,228 @@ public class JavaCodeExecution {
 			}
 		}
 	}
+
+    // Add custom PSet entries to GlobalTag ESSource's toGet VPSet
+    // This handles the GlobalTag ESSource which is of type PoolDBESSource
+    private void customiseNGTForGlobalTagToGet() {
+
+       String logLabel = "[customiseForGlobalTagToGet]";
+       System.out.println("\n" + logLabel + " Starting customization...");
+
+       Integer numChanges = 0;
+
+       // Find the GlobalTag ESSource in the configuration
+       ESSourceInstance globalTagESSource = config.essource("GlobalTag");
+
+       if (globalTagESSource == null) {
+           System.out.println(logLabel + " ERROR: GlobalTag ESSource not found!");
+           return;
+       }
+
+       System.out.println(logLabel + " Found GlobalTag ESSource: " + globalTagESSource.name());
+
+       // Get or create the 'toGet' VPSet parameter within the ESSource
+       VPSetParameter toGetVPSet = (VPSetParameter) globalTagESSource.parameter("toGet");
+
+       if (toGetVPSet == null) {
+           System.out.println(logLabel + " WARNING: 'toGet' VPSet not found in GlobalTag ESSource!");
+           // Optionally create it
+           toGetVPSet = new VPSetParameter("toGet", "", true);
+           globalTagESSource.addParameter(toGetVPSet);
+           System.out.println(logLabel + " Created new 'toGet' VPSet in GlobalTag");
+       }
+
+       // Define the PSets to add to GlobalTag.toGet
+       String[][] psetsToAdd = {
+           {"EcalLaserAPDPNRatiosRcd", "50"},
+           {"SiStripDetVOffRcd", "50"}
+       };
+
+       for (String[] psetInfo : psetsToAdd) {
+           String record = psetInfo[0];
+           String refreshTime = psetInfo[1];
+
+           // Create a new PSet for this record
+           PSetParameter newPSet = new PSetParameter("", "", true);
+
+           // Add the record parameter (string type)
+           StringParameter recordParam = new StringParameter("record", record, true);
+           newPSet.addParameter(recordParam);
+
+           // Add the refreshTime parameter (uint64 type)
+           UInt64Parameter refreshParam = new UInt64Parameter("refreshTime", Long.parseLong(refreshTime), true);
+           newPSet.addParameter(refreshParam);
+
+           // Check if this entry already exists to avoid duplicates
+           boolean entryExists = false;
+           for (int i = 0; i < toGetVPSet.parameterSetCount(); i++) {
+               PSetParameter existingPSet = toGetVPSet.parameterSet(i);
+               Parameter existingRecord = existingPSet.parameter("record");
+               if (existingRecord != null && existingRecord.valueAsString().equals(record)) {
+                   entryExists = true;
+                   System.out.println(logLabel + " Entry for record '" + record + "' already exists, skipping...");
+                   break;
+               }
+           }
+
+           // Add the new PSet if it doesn't already exist
+           if (!entryExists) {
+               toGetVPSet.addParameterSet(newPSet);
+               System.out.println(logLabel + " Added PSet for record: '" + record + "' (refreshTime: " + refreshTime + ")");
+               numChanges++;
+           }
+       }
+
+       // Mark the configuration as changed
+       if (numChanges > 0) {
+           globalTagESSource.setHasChanged();
+       }
+       System.out.println(logLabel + " Completed. Total PSets added: " + numChanges);
+    }
+
+    // Customize prescales for HLT_TestData_v and Dataset_TestDataRaw
+    private void customizeNGTPrescales() {
+
+       String logLabel = "[customizePrescales]";
+       System.out.println("\n" + logLabel + " Starting prescale customization...");
+
+       // Get the PrescaleService from the configuration
+       ServiceInstance prescaleSvc = config.service("PrescaleService");
+       if (prescaleSvc == null) {
+           System.out.println(logLabel + " ERROR: PrescaleService not found!");
+           return;
+       }
+
+       System.out.println(logLabel + " Found PrescaleService");
+
+       // Get the prescaleTable VPSet
+       VPSetParameter prescaleTable = (VPSetParameter) prescaleSvc.parameter("prescaleTable");
+       if (prescaleTable == null) {
+           System.out.println(logLabel + " ERROR: prescaleTable VPSet not found!");
+           return;
+       }
+
+       System.out.println(logLabel + " Found prescaleTable with " + prescaleTable.parameterSetCount() + " entries");
+
+       int pathChanges = 0;
+       // Iterate through all prescale entries
+       for (int i = 0; i < prescaleTable.parameterSetCount(); i++) {
+           PSetParameter pset = prescaleTable.parameterSet(i);
+
+           // Get the pathName parameter
+           StringParameter pathNameParam = (StringParameter) pset.parameter("pathName");
+           if (pathNameParam == null)
+               continue;
+
+           String pathName = (String) pathNameParam.value();
+
+           // Get the prescales parameter
+           VUInt32Parameter prescalesParam = (VUInt32Parameter) pset.parameter("prescales");
+           if (prescalesParam == null)
+               continue;
+
+           // Check if this is HLT_TestData_v (change prescale from 110 to 1)
+           if (pathName.matches("HLT_TestData_v.*")) {
+               System.out.println(logLabel + " Found HLT_TestData_v path: " + pathName);
+
+               // Get current prescales and modify the columns
+               ArrayList<Long> prescales = new ArrayList<Long>();
+               for (int j = 0; j < prescalesParam.vectorSize(); j++) {
+                   Long prescale = (Long) prescalesParam.value(j);
+                   // Change columns from 110 to 1
+                   if (prescale == 110L) {
+                       prescale = 1L;
+                       System.out.println(logLabel + " Changed HLT_TestData_v prescale[" + j + "] from 110 to 1");
+                   }
+                   prescales.add(prescale);
+               }
+
+               //Update the prescales parameter
+               StringBuilder prescalesStr = new StringBuilder();
+               for (int j = 0; j < prescales.size(); j++) {
+                  if (j > 0) prescalesStr.append(",");
+                  prescalesStr.append(prescales.get(j));
+               }
+               prescalesParam.setValue(prescalesStr.toString());
+               pathChanges++;
+           }
+       }
+       // Mark the PrescaleService as changed if we made modifications
+       if (pathChanges > 0) {
+           prescaleSvc.setHasChanged();
+           System.out.println(logLabel + " Updated " + pathChanges + " HLT path(s)");
+       } else {
+           System.out.println(logLabel + " WARNING: No matching paths found");
+       }
+
+       // now change the prescale of the dataset path
+       prescaleAwayTestDataRaw(prescaleTable, prescaleSvc, logLabel);
+
+       System.out.println(logLabel + " Completed");
+    }
+
+    // Add Dataset_TestDataRaw to prescale table if missing
+    private void prescaleAwayTestDataRaw(VPSetParameter prescaleTable,
+                                        ServiceInstance prescaleSvc,
+                                        String logLabel) {
+       final String datasetName = "Dataset_TestDataRaw";
+
+       // Check whether the dataset already exists
+       boolean found = false;
+       for (int i = 0; i < prescaleTable.parameterSetCount(); i++) {
+           PSetParameter pset = prescaleTable.parameterSet(i);
+           StringParameter pathNameParam = (StringParameter) pset.parameter("pathName");
+
+           if (pathNameParam != null &&
+               datasetName.equals(pathNameParam.value())) {
+               found = true;
+               break;
+           }
+       }
+
+       if (found) {
+           System.out.println(logLabel + " Entry for " + datasetName + " already exists.");
+           return;
+       }
+
+       System.out.println(logLabel + " Adding new prescale entry for " + datasetName);
+
+       // Retrieve number of prescale columns
+       VStringParameter labels = (VStringParameter) prescaleSvc.parameter("lvl1Labels");
+       int nColumns = (labels != null) ? labels.vectorSize() : 1;
+
+       // Create a vector filled with zeros
+       StringBuilder prescaleValues = new StringBuilder();
+       for (int i = 0; i < nColumns; i++) {
+           if (i > 0) prescaleValues.append(",");
+           prescaleValues.append("0");
+       }
+
+       // Create new parameter set
+       PSetParameter newEntry = new PSetParameter("prescaleTable");
+       newEntry.addParameter(new StringParameter("pathName", datasetName, true));
+       newEntry.addParameter(new VUInt32Parameter("prescales", prescaleValues.toString(), true));
+
+       // Add the new entry to the prescale table
+       prescaleTable.addParameterSet(newEntry);
+
+       // Mark the service as modified
+       prescaleSvc.setHasChanged();
+       System.out.println(logLabel + " Added " + datasetName + " with prescales: [" + prescaleValues + "]");
+    }
+
+    // full customization function for the NGT demonstrator menu
+    private void customizeNGTDemonstratorMenu() {
+
+       String logLabel = "[customizeNGTDemonstratorMenu]";
+       System.out.println("\n" + logLabel + " Starting NGT demonstrator menu customization...");
+
+       // customise the Global Tag
+       customiseNGTForGlobalTagToGet();
+
+       // customise the prescales
+       customizeNGTPrescales();
+
+       System.out.println(logLabel + " Completed");
+    }
 }


### PR DESCRIPTION
#### PR description:

Introduced a (commented out) convenience customization function `customizeNGTDemonstratorMenu` in `JavaCodeExecution.java` in order to facilitate the mandatory customization of the menus used in the NGT demontrator.
Added:

- routine to modify the `ToGet` `PSet` of `GlobalTag` `ESSource` for NGT menus.
- routine to modify the `Prescale` table to unprescale the `HLT_TestData_v` path and prescale away `Dataset_TestDataRaw`.

#### PR validation:

Tested on top of menu `/dev/CMSSW_16_0_0/GRun/V52`.
The execution [1] of the customization function yields the following difference:

```
-------------------------------------------------------------------------------
ESSources (1):
  -> GlobalTag [PoolDBESSource] CHANGED
       PSet toGet[4] [ADDED]
       PSet toGet[5] [ADDED]

-------------------------------------------------------------------------------
Services (1):
  -> PrescaleService [PrescaleService] CHANGED
       vuint32 prescaleTable[819]::prescales [CHANGED]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
        +  1  [-  110]
       PSet prescaleTable[959] [ADDED]
```

Saved as [`/users/musich/tests/dev/CMSSW_16_0_0/testNGTCustomization/HLT/V3`](https://cmshltcfg-next.app.cern.ch/cfg?path=/users/musich/tests/dev/CMSSW_16_0_0/testNGTCustomization/HLT/V3&db=offline-run3). 
Diff w.r.t. `/dev/CMSSW_16_0_0/GRun/V52` is [here](https://cmshltcfg-next.app.cern.ch/diff?from_cfg=offline-run3:/users/musich/tests/dev/CMSSW_16_0_0/testNGTCustomization/HLT/V1&to_cfg=offline-run3:/users/musich/tests/dev/CMSSW_16_0_0/testNGTCustomization/HLT/V3&tab=pstbldiffs&subtab=changed#state=81117180-2b69-4e30-9284-d1eb300b0f8c&session_state=77ec1dc9-67bb-42e5-b84e-467bb82f4158&iss=https%3A%2F%2Fauth.cern.ch%2Fauth%2Frealms%2Fcern&code=ce4a20f9-12ce-4756-84af-254ce02dbfdc.77ec1dc9-67bb-42e5-b84e-467bb82f4158.1363e04b-e180-4d83-92b3-3aca653d1d8d).

FYI: @sakura-ngt

[1]
<details>

<summary> Printout when executing the customization routine </summary>

```
[JavaCodeExecution] start:

[customizeNGTDemonstratorMenu] Starting NGT demonstrator menu customization...

[customiseForGlobalTagToGet] Starting customization...
[customiseForGlobalTagToGet] Found GlobalTag ESSource: GlobalTag
[customiseForGlobalTagToGet] Added PSet for record: 'EcalLaserAPDPNRatiosRcd' (refreshTime: 50)
[customiseForGlobalTagToGet] Added PSet for record: 'SiStripDetVOffRcd' (refreshTime: 50)
[customiseForGlobalTagToGet] Completed. Total PSets added: 2

[customizePrescales] Starting prescale customization...
[customizePrescales] Found PrescaleService
[customizePrescales] Found prescaleTable with 959 entries
[customizePrescales] Found HLT_TestData_v path: HLT_TestData_v1
[customizePrescales] Changed HLT_TestData_v prescale[0] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[1] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[2] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[3] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[4] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[5] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[6] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[7] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[8] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[9] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[10] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[11] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[12] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[13] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[14] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[15] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[16] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[17] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[18] from 110 to 1
[customizePrescales] Changed HLT_TestData_v prescale[19] from 110 to 1
[customizePrescales] Updated 1 HLT path(s)
[customizePrescales] Adding new prescale entry for Dataset_TestDataRaw
[customizePrescales] Added Dataset_TestDataRaw with prescales: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
[customizePrescales] Completed
[customizeNGTDemonstratorMenu] Completed
```
</details>

